### PR TITLE
Add guest booking flow and admin reservation creation

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,44 +1,69 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+.ant-card {
+  border-radius: 20px;
+  border: none;
+  background: linear-gradient(155deg, rgba(255, 255, 255, 0.92), rgba(247, 250, 255, 0.85));
+  box-shadow: var(--shadow-lg);
+  backdrop-filter: blur(24px);
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
+.ant-typography {
+  color: #0f172a;
 }
 
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
+.ant-btn-primary {
+  background: linear-gradient(135deg, var(--color-primary), var(--color-accent));
+  border: none;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  box-shadow: var(--shadow-md);
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease,
+    filter 0.2s ease;
 }
 
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.ant-btn-primary:not(.ant-btn-disabled):hover,
+.ant-btn-primary:not(.ant-btn-disabled):focus {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 40px -25px rgba(37, 99, 235, 0.7);
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
+.ant-btn-primary:active {
+  transform: translateY(1px);
+}
+
+.ant-input-affix-wrapper,
+.ant-input {
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  padding: 10px 14px;
+  background-color: rgba(255, 255, 255, 0.9);
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    background 0.2s ease;
+}
+
+.ant-input-affix-wrapper-focused,
+.ant-input-affix-wrapper:focus,
+.ant-input-affix-wrapper:hover,
+.ant-input:focus,
+.ant-input:hover {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.12);
+  background-color: #ffffff;
+}
+
+.ant-checkbox-wrapper {
+  color: var(--color-muted);
+}
+
+.ant-alert {
+  border-radius: 12px;
+}
+
+@media (max-width: 640px) {
+  .ant-card {
+    border-radius: 16px;
   }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,14 +1,74 @@
 import React from 'react';
-import {BrowserRouter as Router, Routes, Route, Navigate} from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import Welcome from './pages/Welcome';
 import Login from './pages/Login';
+import Dashboard from './pages/Dashboard';
+import Profile from './pages/Profile';
+import Reservations from './pages/Reservations';
+import Customers from './pages/Customers';
+import Finance from './pages/Finance';
+import { authService } from './services/api';
 import './App.css';
+
+interface RequireAuthProps {
+  children: JSX.Element;
+}
+
+const RequireAuth: React.FC<RequireAuthProps> = ({ children }) => {
+  if (!authService.isAuthenticated()) {
+    return <Navigate to="/login" replace />;
+  }
+  return children;
+};
 
 function App() {
   return (
     <Router>
       <Routes>
-        <Route path="/login" element={<Login/>}/>
-        <Route path="/" element={<Navigate to="/login" replace/>}/>
+        <Route path="/" element={<Welcome />} />
+        <Route path="/welcome" element={<Welcome />} />
+        <Route path="/login" element={<Login />} />
+        <Route
+          path="/dashboard"
+          element={
+            <RequireAuth>
+              <Dashboard />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/reservations"
+          element={
+            <RequireAuth>
+              <Reservations />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/customers"
+          element={
+            <RequireAuth>
+              <Customers />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/finance"
+          element={
+            <RequireAuth>
+              <Finance />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/profile"
+          element={
+            <RequireAuth>
+              <Profile />
+            </RequireAuth>
+          }
+        />
+        <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </Router>
   );

--- a/frontend/src/components/Topbar/index.tsx
+++ b/frontend/src/components/Topbar/index.tsx
@@ -1,0 +1,214 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { NavLink, useLocation, useNavigate } from 'react-router-dom';
+import { Avatar, Badge, Button, Dropdown, List, Popover, Space, Typography, message } from 'antd';
+import type { MenuProps } from 'antd';
+import { BellOutlined, LogoutOutlined, UserOutlined } from '@ant-design/icons';
+import dayjs from 'dayjs';
+import {
+  accountService,
+  authService,
+  businessService,
+  reservationService,
+  type AdminUser,
+  type Business,
+  type Reservation,
+} from '../../services/api';
+import './styles.css';
+
+const { Text, Title } = Typography;
+
+const navItems = [
+  { key: 'dashboard', label: 'Genel Bakış', to: '/dashboard' },
+  { key: 'reservations', label: 'Rezervasyonlar', to: '/reservations' },
+  { key: 'customers', label: 'Müşteriler', to: '/customers' },
+  { key: 'finance', label: 'Finans', to: '/finance' },
+];
+
+const statusLabels: Record<string, string> = {
+  PENDING: 'Onay bekliyor',
+  CONFIRMED: 'Onaylandı',
+  CANCELLED: 'İptal edildi',
+  COMPLETED: 'Tamamlandı',
+};
+
+const profileMenuItems: MenuProps['items'] = [
+  {
+    key: 'profile',
+    label: 'Profilimi Görüntüle',
+  },
+  {
+    key: 'security',
+    label: 'Güvenlik Ayarları',
+  },
+];
+
+const Topbar: React.FC = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [messageApi, contextHolder] = message.useMessage();
+  const [user, setUser] = useState<AdminUser | null>(null);
+  const [business, setBusiness] = useState<Business | null>(null);
+  const [recentReservations, setRecentReservations] = useState<Reservation[]>([]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadInitialData = async () => {
+      try {
+        const [accountResponse, businessResponse, reservationsResponse] = await Promise.all([
+          accountService.getProfile().catch(() => null),
+          businessService.list({ page: 0, size: 1 }).catch(() => null),
+          reservationService.list({ page: 0, size: 5, sort: 'date,desc' }).catch(() => null),
+        ]);
+
+        if (!isMounted) {
+          return;
+        }
+
+        if (accountResponse) {
+          setUser(accountResponse.data);
+        }
+
+        if (businessResponse && businessResponse.items.length > 0) {
+          setBusiness(businessResponse.items[0]);
+        }
+
+        if (reservationsResponse) {
+          setRecentReservations(reservationsResponse.items);
+        }
+      } catch (error) {
+        // Sessizce geç ve topbar'ı çalışır durumda bırak
+        console.warn('Topbar verileri yüklenirken hata oluştu', error);
+      }
+    };
+
+    loadInitialData();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const notifications = useMemo(
+    () =>
+      recentReservations.map(reservation => {
+        const customerName = [reservation.customer?.firstName, reservation.customer?.lastName].filter(Boolean).join(' ');
+        const serviceName = reservation.service?.name ?? 'Belirlenmemiş hizmet';
+        return {
+          key: reservation.id,
+          title: statusLabels[reservation.status] ?? reservation.status,
+          description: `${customerName || 'Müşteri'} · ${serviceName}`,
+          time: dayjs(reservation.date).format('DD MMM YYYY HH:mm'),
+        };
+      }),
+    [recentReservations],
+  );
+
+  const notificationCount = notifications.length;
+
+  const brandName = business?.name ?? 'Rezervasyon Yönetimi';
+  const brandInitials = useMemo(() => {
+    return brandName
+      .split(' ')
+      .filter(Boolean)
+      .slice(0, 2)
+      .map(part => part.charAt(0).toUpperCase())
+      .join('')
+      .padEnd(2, 'R')
+      .slice(0, 2);
+  }, [brandName]);
+
+  const brandSubtitle = business?.type ? business.type.toLowerCase().replace(/_/g, ' ') : 'Yönetim Merkezi';
+
+  const handleProfileMenuClick: MenuProps['onClick'] = ({ key }) => {
+    if (key === 'profile' || key === 'security') {
+      navigate('/profile');
+    }
+  };
+
+  const handleLogout = () => {
+    messageApi.success('Oturum başarıyla kapatıldı.');
+    authService.logout();
+  };
+
+  const notificationContent = (
+    <div className="dashboard-notification-content">
+      {notifications.length > 0 ? (
+        <List
+          dataSource={notifications}
+          renderItem={item => (
+            <List.Item key={item.key} className="notification-item">
+              <div className="notification-copy">
+                <Text className="notification-title">{item.title}</Text>
+                <Text className="notification-description">{item.description}</Text>
+              </div>
+              <Text className="notification-time">{item.time}</Text>
+            </List.Item>
+          )}
+        />
+      ) : (
+        <div className="notification-empty">
+          <Text>Yeni bildirim bulunmuyor.</Text>
+        </div>
+      )}
+      <Button type="link" className="notification-settings" onClick={() => navigate('/profile')}>
+        Bildirim tercihlerini yönet
+      </Button>
+    </div>
+  );
+
+  return (
+    <>
+      {contextHolder}
+      <nav className="dashboard-topbar">
+        <div className="dashboard-brand">
+          <div className="brand-mark">{brandInitials}</div>
+          <div className="brand-copy">
+            <Text className="brand-eyebrow">{brandName}</Text>
+            <Title level={5}>{brandSubtitle}</Title>
+          </div>
+        </div>
+
+        <div className="topbar-nav" role="navigation" aria-label="Ana menü">
+          {navItems.map(item => (
+            <NavLink
+              key={item.key}
+              to={item.to}
+              className={({ isActive }) => `topbar-nav-link ${isActive ? 'topbar-nav-link-active' : ''}`}
+            >
+              {item.label}
+              {location.pathname.startsWith(item.to) && <span className="topbar-nav-indicator" aria-hidden />}
+            </NavLink>
+          ))}
+        </div>
+
+        <Space size={16} className="dashboard-topbar-actions" align="center">
+          <Popover placement="bottomRight" trigger="click" overlayClassName="dashboard-notification-popover" content={notificationContent}>
+            <Badge count={notificationCount} overflowCount={9} color="#38bdf8" offset={[2, -4]}>
+              <button type="button" className="topbar-icon-button" aria-label="Bildirimler">
+                <BellOutlined />
+              </button>
+            </Badge>
+          </Popover>
+          <Dropdown
+            placement="bottomRight"
+            overlayClassName="dashboard-profile-dropdown"
+            menu={{ items: profileMenuItems, onClick: handleProfileMenuClick }}
+          >
+            <button type="button" className="topbar-profile" aria-haspopup="menu">
+              <Avatar src={user?.imageUrl} size={40} icon={<UserOutlined />} />
+              <span className="topbar-profile-name">
+                {[user?.firstName, user?.lastName].filter(Boolean).join(' ') || user?.login || 'Kullanıcı'}
+              </span>
+            </button>
+          </Dropdown>
+          <Button type="primary" icon={<LogoutOutlined />} className="topbar-logout" onClick={handleLogout}>
+            Çıkış Yap
+          </Button>
+        </Space>
+      </nav>
+    </>
+  );
+};
+
+export default Topbar;

--- a/frontend/src/components/Topbar/styles.css
+++ b/frontend/src/components/Topbar/styles.css
@@ -1,0 +1,307 @@
+.dashboard-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: clamp(16px, 4vw, 32px);
+  padding: clamp(18px, 3vw, 24px) clamp(20px, 4vw, 32px);
+  border-radius: 28px;
+  background: linear-gradient(130deg, rgba(15, 23, 42, 0.92), rgba(30, 64, 175, 0.88));
+  box-shadow: 0 45px 80px -60px rgba(15, 23, 42, 0.7);
+  color: #ffffff;
+}
+
+.dashboard-brand {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-shrink: 0;
+}
+
+.brand-mark {
+  width: 52px;
+  height: 52px;
+  border-radius: 18px;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(140deg, rgba(37, 99, 235, 0.95), rgba(56, 189, 248, 0.9));
+  color: #ffffff;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.brand-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.brand-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 11px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.dashboard-topbar h5.ant-typography {
+  margin: 0;
+  color: #ffffff;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+}
+
+.topbar-nav {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(12px, 2vw, 24px);
+  flex: 1;
+}
+
+.topbar-nav-link {
+  position: relative;
+  padding: 10px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.78);
+  transition:
+    background 0.2s ease,
+    color 0.2s ease,
+    transform 0.2s ease;
+  text-decoration: none;
+}
+
+.topbar-nav-link:hover {
+  color: #ffffff;
+  background: rgba(255, 255, 255, 0.12);
+  transform: translateY(-1px);
+}
+
+.topbar-nav-link-active {
+  color: #ffffff;
+  background: rgba(37, 99, 235, 0.28);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+}
+
+.topbar-nav-indicator {
+  position: absolute;
+  inset-inline: 20px;
+  bottom: 6px;
+  height: 2px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(96, 165, 250, 0.9), rgba(56, 189, 248, 0.9));
+}
+
+.dashboard-topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-shrink: 0;
+}
+
+.topbar-icon-button {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: none;
+  display: grid;
+  place-items: center;
+  background: rgba(15, 23, 42, 0.75);
+  color: #ffffff;
+  box-shadow: 0 30px 50px -38px rgba(14, 116, 144, 0.8);
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
+  cursor: pointer;
+}
+
+.topbar-icon-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 24px 45px -32px rgba(56, 189, 248, 0.8);
+}
+
+.dashboard-topbar .ant-badge-count {
+  box-shadow: none;
+  font-weight: 600;
+}
+
+.topbar-profile {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.1);
+  padding: 6px 16px 6px 8px;
+  border-radius: 999px;
+  color: #ffffff;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background 0.2s ease,
+    transform 0.2s ease;
+}
+
+.topbar-profile:hover {
+  background: rgba(255, 255, 255, 0.18);
+  transform: translateY(-1px);
+}
+
+.topbar-profile .ant-avatar {
+  border: 2px solid rgba(255, 255, 255, 0.35);
+  box-shadow: 0 20px 45px -35px rgba(30, 58, 138, 0.9);
+}
+
+.topbar-profile-name {
+  color: inherit;
+}
+
+.topbar-logout {
+  border-radius: 999px;
+  padding: 0 20px;
+  height: 46px;
+  display: inline-flex;
+  align-items: center;
+}
+
+.dashboard-notification-popover .ant-popover-inner {
+  border-radius: 20px;
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.97), rgba(240, 246, 255, 0.92));
+  box-shadow: 0 35px 70px -50px rgba(15, 23, 42, 0.55);
+  padding: 20px;
+}
+
+.dashboard-profile-dropdown .ant-dropdown-menu {
+  border-radius: 16px;
+  padding: 8px;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.96), rgba(231, 245, 255, 0.88));
+  box-shadow: 0 30px 60px -45px rgba(15, 23, 42, 0.55);
+}
+
+.dashboard-profile-dropdown .ant-dropdown-menu-item {
+  border-radius: 12px;
+  font-weight: 600;
+  color: rgba(30, 41, 59, 0.85);
+}
+
+.dashboard-profile-dropdown .ant-dropdown-menu-item:hover {
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--color-primary);
+}
+
+.dashboard-notification-content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: min(320px, 80vw);
+}
+
+.notification-item {
+  align-items: flex-start !important;
+  padding: 12px 0;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.notification-item:last-child {
+  border-bottom: none;
+}
+
+.notification-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.notification-title {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.notification-description {
+  color: rgba(71, 85, 105, 0.78);
+}
+
+.notification-time {
+  font-size: 12px;
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.notification-settings {
+  align-self: flex-end;
+  padding: 0;
+  font-weight: 600;
+}
+
+.notification-settings span {
+  background: linear-gradient(135deg, var(--color-primary), var(--color-accent));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.notification-empty {
+  display: grid;
+  place-items: center;
+  padding: 24px 0;
+  color: rgba(15, 23, 42, 0.65);
+  font-weight: 500;
+}
+
+@media (max-width: 960px) {
+  .dashboard-topbar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .dashboard-topbar-actions {
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .topbar-logout {
+    order: 3;
+  }
+}
+
+@media (max-width: 1200px) {
+  .dashboard-topbar {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .dashboard-brand {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .topbar-nav {
+    flex-wrap: wrap;
+  }
+
+  .dashboard-topbar-actions {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+@media (max-width: 640px) {
+  .topbar-icon-button {
+    width: 44px;
+    height: 44px;
+  }
+
+  .topbar-nav {
+    gap: 8px;
+  }
+
+  .topbar-nav-link {
+    padding: 8px 14px;
+  }
+
+  .topbar-nav-indicator {
+    inset-inline: 16px;
+  }
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,16 +1,21 @@
 :root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
+  font-family: 'Inter', 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  line-height: 1.6;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #f5f5f5;
-
+  color: #111827;
+  background-color: #f4f6fb;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  --color-primary: #2563eb;
+  --color-primary-strong: #1d4ed8;
+  --color-accent: #38bdf8;
+  --color-surface: #ffffff;
+  --color-muted: #6b7280;
+  --shadow-lg: 0 30px 60px -40px rgba(15, 23, 42, 0.45);
+  --shadow-md: 0 18px 40px -30px rgba(15, 23, 42, 0.35);
 }
 
 * {
@@ -20,14 +25,41 @@
 }
 
 body {
-  margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
   min-height: 100vh;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(37, 99, 235, 0.18), transparent 45%),
+    radial-gradient(circle at 80% 0%, rgba(56, 189, 248, 0.15), transparent 50%),
+    linear-gradient(135deg, #f8fafc 0%, #eef2ff 45%, #e0f2fe 100%);
+  background-attachment: fixed;
+  color: inherit;
+}
+
+main {
+  width: 100%;
+}
+
+a {
+  color: var(--color-primary);
+  text-decoration: none;
+  transition:
+    color 0.2s ease,
+    opacity 0.2s ease;
+}
+
+a:hover {
+  color: var(--color-primary-strong);
+}
+
+button {
+  font-family: inherit;
 }
 
 #root {
-  width: 100%;
-  height: 100vh;
+  min-height: 100vh;
+}
+
+@media (max-width: 640px) {
+  body {
+    background-attachment: scroll;
+  }
 }

--- a/frontend/src/pages/Customers/index.tsx
+++ b/frontend/src/pages/Customers/index.tsx
@@ -1,0 +1,368 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Avatar, Card, Empty, List, Progress, Select, Space, Spin, Tag, Typography } from 'antd';
+import { CrownOutlined, CustomerServiceOutlined, HeartOutlined, SmileOutlined } from '@ant-design/icons';
+import dayjs from 'dayjs';
+import Topbar from '../../components/Topbar';
+import '../../styles/workspace.css';
+import './styles.css';
+import { customerService, paymentService, reservationService, type Customer, type Payment, type Reservation } from '../../services/api';
+
+const { Title, Text } = Typography;
+
+const currencyFormatter = new Intl.NumberFormat('tr-TR', {
+  style: 'currency',
+  currency: 'TRY',
+  maximumFractionDigits: 0,
+});
+
+interface CustomerInsight extends Customer {
+  reservationCount: number;
+  lastReservation?: string;
+  nextReservation?: string;
+  nextStatus?: string;
+  totalPaid: number;
+}
+
+const Customers: React.FC = () => {
+  const [customers, setCustomers] = useState<Customer[]>([]);
+  const [reservations, setReservations] = useState<Reservation[]>([]);
+  const [payments, setPayments] = useState<Payment[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [segmentFilter, setSegmentFilter] = useState<string>('all');
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchData = async () => {
+      try {
+        const [customerResponse, reservationResponse, paymentResponse] = await Promise.all([
+          customerService.list({ page: 0, size: 200, sort: 'id,desc' }),
+          reservationService.list({ page: 0, size: 200, sort: 'date,desc' }),
+          paymentService.list({ page: 0, size: 200, sort: 'id,desc' }),
+        ]);
+
+        if (!isMounted) {
+          return;
+        }
+
+        setCustomers(customerResponse.items);
+        setReservations(reservationResponse.items);
+        setPayments(paymentResponse.items);
+      } catch {
+        if (isMounted) {
+          setError('Müşteri verileri alınamadı.');
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchData();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const insights = useMemo<CustomerInsight[]>(() => {
+    const paymentsByCustomer = payments.reduce<Record<number, number>>((acc, payment) => {
+      if (payment.customer?.id && payment.status === 'PAID') {
+        acc[payment.customer.id] = (acc[payment.customer.id] ?? 0) + Number(payment.amount ?? 0);
+      }
+      return acc;
+    }, {});
+
+    return customers.map(customer => {
+      const relatedReservations = reservations
+        .filter(reservation => reservation.customer?.id === customer.id)
+        .sort((a, b) => dayjs(b.date).valueOf() - dayjs(a.date).valueOf());
+
+      const lastReservation = relatedReservations[0];
+      const upcomingReservation = relatedReservations.find(reservation => dayjs(reservation.date).isAfter(dayjs()));
+
+      return {
+        ...customer,
+        reservationCount: relatedReservations.length,
+        lastReservation: lastReservation?.date,
+        nextReservation: upcomingReservation?.date,
+        nextStatus: upcomingReservation?.status,
+        totalPaid: paymentsByCustomer[customer.id ?? 0] ?? 0,
+      };
+    });
+  }, [customers, reservations, payments]);
+
+  const totalCustomers = customers.length;
+  const customersWithReservations = insights.filter(customer => customer.reservationCount > 0).length;
+  const loyalCustomers = insights.filter(customer => customer.reservationCount > 1).length;
+  const totalRevenue = payments.filter(payment => payment.status === 'PAID').reduce((sum, payment) => sum + Number(payment.amount ?? 0), 0);
+  const averageRevenuePerCustomer = customersWithReservations ? totalRevenue / customersWithReservations : 0;
+
+  const customerHighlights = [
+    {
+      title: 'Toplam Müşteri',
+      value: totalCustomers,
+      helper: `${customersWithReservations} kayıtlı rezervasyon`,
+      progress: 100,
+      accent: '#2563eb',
+    },
+    {
+      title: 'Aktif İlişkiler',
+      value: customersWithReservations,
+      helper: `${totalCustomers ? Math.round((customersWithReservations / totalCustomers) * 100) : 0}% oran`,
+      progress: totalCustomers ? Math.round((customersWithReservations / totalCustomers) * 100) : 0,
+      accent: '#6366f1',
+    },
+    {
+      title: 'Tekrar Eden Müşteri',
+      value: loyalCustomers,
+      helper: `${customersWithReservations ? Math.round((loyalCustomers / customersWithReservations) * 100) : 0}% dönüşüm`,
+      progress: customersWithReservations ? Math.round((loyalCustomers / customersWithReservations) * 100) : 0,
+      accent: '#10b981',
+    },
+    {
+      title: 'Müşteri Başına Gelir',
+      value: currencyFormatter.format(averageRevenuePerCustomer || 0),
+      helper: `Toplam gelir: ${currencyFormatter.format(totalRevenue)}`,
+      progress: totalRevenue ? Math.min(100, Math.round((averageRevenuePerCustomer / (totalRevenue || 1)) * 100)) : 0,
+      accent: '#f97316',
+    },
+  ];
+
+  const filteredInsights = useMemo(() => {
+    if (segmentFilter === 'all') {
+      return insights;
+    }
+
+    if (segmentFilter === 'loyal') {
+      return insights.filter(customer => customer.reservationCount > 1);
+    }
+
+    if (segmentFilter === 'inactive') {
+      return insights.filter(customer => customer.reservationCount === 0);
+    }
+
+    return insights;
+  }, [insights, segmentFilter]);
+
+  const servicePreferences = useMemo(() => {
+    const counts = reservations.reduce<Record<string, Set<number>>>((acc, reservation) => {
+      const serviceName = reservation.service?.name ?? 'Hizmet bilgisi yok';
+      const customerId = reservation.customer?.id;
+      if (!customerId) {
+        return acc;
+      }
+      if (!acc[serviceName]) {
+        acc[serviceName] = new Set();
+      }
+      acc[serviceName].add(customerId);
+      return acc;
+    }, {});
+
+    return Object.entries(counts)
+      .map(([serviceName, customerSet]) => ({
+        serviceName,
+        uniqueCustomers: customerSet.size,
+      }))
+      .sort((a, b) => b.uniqueCustomers - a.uniqueCustomers)
+      .slice(0, 5);
+  }, [reservations]);
+
+  const pendingFollowUps = useMemo(() => {
+    return reservations
+      .filter(reservation => reservation.status === 'PENDING')
+      .sort((a, b) => dayjs(a.date).valueOf() - dayjs(b.date).valueOf())
+      .slice(0, 5)
+      .map(reservation => {
+        const customerName = [reservation.customer?.firstName, reservation.customer?.lastName].filter(Boolean).join(' ') || 'Müşteri';
+        const serviceName = reservation.service?.name ?? 'Hizmet bilgisi yok';
+        return {
+          id: reservation.id,
+          title: serviceName,
+          owner: customerName,
+          due: dayjs(reservation.date).format('DD MMM YYYY HH:mm'),
+          status: reservation.status,
+        };
+      });
+  }, [reservations]);
+
+  return (
+    <main className="workspace-page customers-page">
+      <Topbar />
+      <header className="workspace-header">
+        <div>
+          <Text className="workspace-eyebrow">Müşteri Analitiği</Text>
+          <Title level={2}>Müşteri Deneyimi Merkezi</Title>
+          <Text className="workspace-subtitle">
+            Sadakat üyelerinizi tanıyın, segment performansını takip edin ve kişiselleştirilmiş aksiyonlarla gelir etkisini artırın.
+          </Text>
+        </div>
+        <Space size={16} className="workspace-actions" wrap>
+          <Select
+            value={segmentFilter}
+            onChange={value => setSegmentFilter(value)}
+            options={[
+              { label: 'Tüm Müşteriler', value: 'all' },
+              { label: 'Tekrar Eden', value: 'loyal' },
+              { label: 'Pasif', value: 'inactive' },
+            ]}
+          />
+          <Select
+            defaultValue="quarter"
+            options={[
+              { label: 'Bu Ay', value: 'month' },
+              { label: 'Bu Çeyrek', value: 'quarter' },
+              { label: 'Bu Yıl', value: 'year' },
+            ]}
+          />
+        </Space>
+      </header>
+
+      {loading ? (
+        <div className="workspace-loader">
+          <Spin size="large" />
+        </div>
+      ) : (
+        <>
+          {error && (
+            <div className="workspace-error">
+              <Text type="danger">{error}</Text>
+            </div>
+          )}
+
+          <section className="workspace-section customers-overview">
+            <div className="workspace-stat-grid">
+              {customerHighlights.map(highlight => (
+                <Card key={highlight.title} className="workspace-stat-card" bordered={false}>
+                  <Text className="workspace-stat-label">{highlight.title}</Text>
+                  <div className="customers-stat-value">
+                    <Title level={3}>{highlight.value}</Title>
+                    <span className="customers-helper" style={{ color: highlight.accent }}>
+                      {highlight.helper}
+                    </span>
+                  </div>
+                  <Progress
+                    percent={Math.min(100, highlight.progress)}
+                    strokeColor={highlight.accent}
+                    trailColor="rgba(148, 163, 184, 0.18)"
+                    strokeLinecap="round"
+                  />
+                </Card>
+              ))}
+            </div>
+          </section>
+
+          <section className="workspace-section customers-grid">
+            <Card className="workspace-card customers-list-card" bordered={false}>
+              <div className="workspace-card-header">
+                <div>
+                  <Text className="workspace-stat-label">Müşteri Profilleri</Text>
+                  <Title level={4}>İlişki Durumu</Title>
+                </div>
+                <Tag icon={<CrownOutlined />} className="workspace-pill">
+                  {customersWithReservations} aktif müşteri
+                </Tag>
+              </div>
+              <List
+                className="customers-list"
+                dataSource={filteredInsights}
+                locale={{ emptyText: <Empty description="Kayıt bulunamadı." /> }}
+                renderItem={customer => (
+                  <List.Item className="customers-item" key={customer.id}>
+                    <List.Item.Meta
+                      avatar={<Avatar>{(customer.firstName || customer.lastName || '?').charAt(0)}</Avatar>}
+                      title={`${customer.firstName ?? ''} ${customer.lastName ?? ''}`.trim() || customer.email}
+                      description={
+                        <div className="customers-interests">
+                          <Tag color="blue">{customer.email}</Tag>
+                          <Tag color="cyan">{customer.phone}</Tag>
+                          <Tag color="purple">{`${customer.reservationCount} rezervasyon`}</Tag>
+                        </div>
+                      }
+                    />
+                    <div className="customers-meta">
+                      <Text className="customers-meta-label">Son Rezervasyon</Text>
+                      <Text className="customers-meta-value">
+                        {customer.lastReservation ? dayjs(customer.lastReservation).format('DD MMM YYYY') : 'Kayıt yok'}
+                      </Text>
+                      <Text className="customers-meta-label">Bekleyen</Text>
+                      <Text className="customers-meta-value">
+                        {customer.nextReservation
+                          ? `${dayjs(customer.nextReservation).format('DD MMM HH:mm')} · ${customer.nextStatus ?? ''}`
+                          : 'Aktif işlem yok'}
+                      </Text>
+                      <Text className="customers-meta-label">Toplam Ödeme</Text>
+                      <Text className="customers-meta-value">{currencyFormatter.format(customer.totalPaid)}</Text>
+                    </div>
+                  </List.Item>
+                )}
+              />
+            </Card>
+
+            <Card className="workspace-card customers-segments-card" bordered={false}>
+              <div className="workspace-card-header">
+                <div>
+                  <Text className="workspace-stat-label">Hizmet Tercihleri</Text>
+                  <Title level={4}>En Popüler Seçimler</Title>
+                </div>
+                <Tag icon={<HeartOutlined />} className="workspace-pill">
+                  {servicePreferences.length} kategori
+                </Tag>
+              </div>
+              <div className="customers-segments">
+                {servicePreferences.length > 0 ? (
+                  servicePreferences.map(preference => (
+                    <div key={preference.serviceName} className="customers-segment-item">
+                      <div className="customers-segment-header">
+                        <Text className="customers-segment-name">{preference.serviceName}</Text>
+                        <Text className="customers-segment-value">{preference.uniqueCustomers} müşteri</Text>
+                      </div>
+                      <Progress
+                        percent={Math.min(100, Math.round((preference.uniqueCustomers / (totalCustomers || 1)) * 100))}
+                        strokeColor="#2563eb"
+                        trailColor="rgba(148, 163, 184, 0.18)"
+                        strokeLinecap="round"
+                      />
+                    </div>
+                  ))
+                ) : (
+                  <Empty description="Hizmet tercih verisi bulunmuyor." image={Empty.PRESENTED_IMAGE_SIMPLE} />
+                )}
+              </div>
+
+              <div className="customers-follow-ups">
+                <div className="customers-follow-ups-header">
+                  <Text className="workspace-stat-label">Takip Gerektiren Rezervasyonlar</Text>
+                  <Tag icon={<CustomerServiceOutlined />} className="workspace-pill">
+                    {pendingFollowUps.length} kayıt
+                  </Tag>
+                </div>
+                <List
+                  dataSource={pendingFollowUps}
+                  locale={{ emptyText: <Empty description="Bekleyen rezervasyon bulunmuyor." /> }}
+                  renderItem={item => (
+                    <List.Item key={item.id} className="customers-follow-up-item">
+                      <div className="customers-follow-up-main">
+                        <Text className="customers-follow-up-title">{item.title}</Text>
+                        <Text className="customers-follow-up-owner">{item.owner}</Text>
+                      </div>
+                      <div className="customers-follow-up-meta">
+                        <Tag color="gold" icon={<SmileOutlined />}>
+                          {item.due}
+                        </Tag>
+                      </div>
+                    </List.Item>
+                  )}
+                />
+              </div>
+            </Card>
+          </section>
+        </>
+      )}
+    </main>
+  );
+};
+
+export default Customers;

--- a/frontend/src/pages/Customers/styles.css
+++ b/frontend/src/pages/Customers/styles.css
@@ -1,0 +1,239 @@
+.customers-page .workspace-stat-card .ant-card-body {
+  gap: 16px;
+}
+
+.customers-stat-value {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.customers-stat-value h3.ant-typography {
+  margin: 0;
+  font-size: clamp(26px, 2.6vw, 32px);
+}
+
+.customers-helper {
+  font-weight: 600;
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.04);
+  border: 1px solid currentColor;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.45);
+}
+
+.customers-grid {
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+}
+
+.customers-list {
+  margin-top: 12px;
+}
+
+.customers-item {
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  padding: 18px 0 !important;
+}
+
+.customers-item:last-child {
+  border-bottom: none;
+  padding-bottom: 0 !important;
+}
+
+.customers-item .ant-avatar {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.customers-interests {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  color: rgba(71, 85, 105, 0.75);
+}
+
+.customers-interests .ant-tag {
+  border-radius: 999px;
+  padding: 0 12px;
+  font-weight: 600;
+}
+
+.customers-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+}
+
+.customers-meta-label {
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(71, 85, 105, 0.65);
+}
+
+.customers-meta-value {
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.85);
+}
+
+.customers-tier.ant-tag {
+  border-radius: 999px;
+  padding: 2px 12px;
+  font-weight: 600;
+  border: none;
+}
+
+.customers-spend {
+  font-weight: 700;
+  color: rgba(15, 23, 42, 0.85);
+}
+
+.customers-visits {
+  color: rgba(71, 85, 105, 0.75);
+}
+
+.customers-segments {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.customers-segment-item {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.customers-segment-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.customers-segment-name {
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.85);
+}
+
+.customers-segment-tag.ant-tag {
+  border-radius: 999px;
+  padding: 2px 10px;
+  font-weight: 600;
+  border: none;
+}
+
+.customers-follow-ups {
+  margin-top: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.customers-follow-ups-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.customers-follow-up-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px;
+  border-radius: 16px;
+  background: linear-gradient(140deg, rgba(37, 99, 235, 0.06), rgba(56, 189, 248, 0.08));
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.customers-follow-up-item h5.ant-typography {
+  margin: 0;
+}
+
+.customers-follow-up-main {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.customers-follow-up-title {
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.9);
+}
+
+.customers-follow-up-owner {
+  color: rgba(71, 85, 105, 0.75);
+}
+
+.customers-follow-up-meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.customers-follow-up-status.ant-tag {
+  border-radius: 999px;
+  padding: 2px 12px;
+  font-weight: 600;
+  border: none;
+}
+
+.customers-feedback-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 20px;
+}
+
+.customers-feedback-card {
+  margin: 0;
+  padding: 20px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.8);
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 24px 45px -36px rgba(15, 23, 42, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.customers-feedback-card p {
+  margin: 0;
+  color: rgba(30, 41, 59, 0.78);
+  font-style: italic;
+}
+
+.customers-feedback-card footer {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: rgba(15, 23, 42, 0.65);
+}
+
+.customers-feedback-card strong {
+  color: rgba(15, 23, 42, 0.85);
+}
+
+@media (max-width: 960px) {
+  .customers-meta {
+    align-items: flex-start;
+  }
+
+  .customers-meta {
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 640px) {
+  .customers-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .customers-stat-value {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/frontend/src/pages/Dashboard/index.tsx
+++ b/frontend/src/pages/Dashboard/index.tsx
@@ -1,0 +1,314 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Avatar, Card, DatePicker, Empty, List, Progress, Select, Space, Spin, Tag, Typography } from 'antd';
+import { CalendarOutlined, DollarCircleOutlined, TeamOutlined } from '@ant-design/icons';
+import dayjs from 'dayjs';
+import Topbar from '../../components/Topbar';
+import {
+  customerService,
+  paymentService,
+  reservationService,
+  type Customer,
+  type Payment,
+  type Reservation,
+  type ReservationStatus,
+} from '../../services/api';
+import './styles.css';
+
+const { Title, Text } = Typography;
+const { RangePicker } = DatePicker;
+
+const statusColors: Record<ReservationStatus, string> = {
+  PENDING: 'processing',
+  CONFIRMED: 'success',
+  CANCELLED: 'error',
+  COMPLETED: 'default',
+};
+
+const statusLabels: Record<ReservationStatus, string> = {
+  PENDING: 'Onay bekliyor',
+  CONFIRMED: 'Onaylandı',
+  CANCELLED: 'İptal edildi',
+  COMPLETED: 'Tamamlandı',
+};
+
+const currencyFormatter = new Intl.NumberFormat('tr-TR', {
+  style: 'currency',
+  currency: 'TRY',
+  maximumFractionDigits: 0,
+});
+
+const Dashboard: React.FC = () => {
+  const [reservations, setReservations] = useState<Reservation[]>([]);
+  const [payments, setPayments] = useState<Payment[]>([]);
+  const [customers, setCustomers] = useState<Customer[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchData = async () => {
+      try {
+        const [reservationResponse, paymentResponse, customerResponse] = await Promise.all([
+          reservationService.list({ page: 0, size: 200, sort: 'date,desc' }),
+          paymentService.list({ page: 0, size: 200, sort: 'id,desc' }),
+          customerService.list({ page: 0, size: 200, sort: 'id,desc' }),
+        ]);
+
+        if (!isMounted) {
+          return;
+        }
+
+        setReservations(reservationResponse.items);
+        setPayments(paymentResponse.items);
+        setCustomers(customerResponse.items);
+      } catch {
+        if (isMounted) {
+          setError('Veriler yüklenirken bir sorun oluştu.');
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchData();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const reservationStats = useMemo(() => {
+    const total = reservations.length;
+    const today = reservations.filter(reservation => dayjs(reservation.date).isSame(dayjs(), 'day')).length;
+    const confirmed = reservations.filter(reservation => reservation.status === 'CONFIRMED').length;
+    const pending = reservations.filter(reservation => reservation.status === 'PENDING').length;
+    const cancelled = reservations.filter(reservation => reservation.status === 'CANCELLED').length;
+    const active = confirmed + pending;
+    const cancellationRate = total ? ((cancelled / total) * 100).toFixed(1) : '0.0';
+
+    return [
+      {
+        title: 'Bugünkü Rezervasyonlar',
+        value: today,
+        badge: total ? `${((today / total) * 100).toFixed(0)}%` : '0%',
+        badgeTone: today > 0 ? 'positive' : 'neutral',
+        descriptor: `Toplam kayıt: ${total}`,
+      },
+      {
+        title: 'Onaylı Rezervasyonlar',
+        value: confirmed,
+        badge: total ? `${((confirmed / total) * 100).toFixed(0)}%` : '0%',
+        badgeTone: confirmed > 0 ? 'positive' : 'neutral',
+        descriptor: `Aktif rezervasyon: ${active}`,
+      },
+      {
+        title: 'Bekleyen İşlemler',
+        value: pending,
+        badge: `${customers.length} müşteri`,
+        badgeTone: pending > 0 ? 'warning' : 'neutral',
+        descriptor: 'Onay için sırada',
+      },
+      {
+        title: 'İptal Oranı',
+        value: `${cancellationRate}%`,
+        badge: `${cancelled} kayıt`,
+        badgeTone: cancelled > 0 ? 'negative' : 'positive',
+        descriptor: 'Operasyon kalitesi',
+      },
+    ];
+  }, [reservations, customers]);
+
+  const upcomingReservations = useMemo(() => {
+    return reservations
+      .filter(reservation => dayjs(reservation.date).isAfter(dayjs().subtract(1, 'day')))
+      .sort((a, b) => dayjs(a.date).valueOf() - dayjs(b.date).valueOf())
+      .slice(0, 5);
+  }, [reservations]);
+
+  const serviceDistribution = useMemo(() => {
+    if (!reservations.length) {
+      return [];
+    }
+
+    const counts = new Map<string, number>();
+    reservations.forEach(reservation => {
+      const label = reservation.service?.name ?? 'Hizmet bilgisi yok';
+      counts.set(label, (counts.get(label) ?? 0) + 1);
+    });
+
+    const total = reservations.length;
+
+    return Array.from(counts.entries())
+      .map(([label, count]) => ({
+        label,
+        count,
+        ratio: Math.round((count / total) * 100),
+      }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 4);
+  }, [reservations]);
+
+  const revenueSummary = useMemo(() => {
+    if (!payments.length) {
+      return {
+        total: 0,
+        items: [],
+      };
+    }
+
+    const sumByStatus = (status: string) =>
+      payments.filter(payment => payment.status === status).reduce((total, payment) => total + Number(payment.amount ?? 0), 0);
+
+    const paid = sumByStatus('PAID');
+    const pending = sumByStatus('PENDING');
+    const refunded = sumByStatus('REFUNDED');
+
+    return {
+      total: paid,
+      items: [
+        { key: 'paid', label: 'Tahsil Edilen', amount: paid, tone: 'positive' },
+        { key: 'pending', label: 'Bekleyen Tahsilat', amount: pending, tone: pending > 0 ? 'warning' : 'neutral' },
+        { key: 'refunded', label: 'İade Edilen', amount: refunded, tone: refunded > 0 ? 'negative' : 'neutral' },
+      ],
+    };
+  }, [payments]);
+
+  return (
+    <main className="dashboard-page">
+      <Topbar />
+      <header className="dashboard-header">
+        <div>
+          <Text className="dashboard-eyebrow">Genel Bakış</Text>
+          <Title level={2}>Rezervasyon Paneli</Title>
+          <Text className="dashboard-subtitle">
+            Güncel rezervasyonlarınızı takip edin, gelir durumunu görün ve ekip önceliklerini planlayın.
+          </Text>
+        </div>
+        <Space size={16} className="dashboard-actions" wrap>
+          <RangePicker suffixIcon={<CalendarOutlined />} className="dashboard-range-picker" popupClassName="dashboard-picker-dropdown" />
+          <Select
+            className="dashboard-select"
+            defaultValue="today"
+            options={[
+              { label: 'Bugün', value: 'today' },
+              { label: 'Bu Hafta', value: 'week' },
+              { label: 'Bu Ay', value: 'month' },
+            ]}
+          />
+        </Space>
+      </header>
+
+      {loading ? (
+        <div className="dashboard-loading">
+          <Spin size="large" />
+        </div>
+      ) : (
+        <>
+          {error && (
+            <div className="dashboard-error">
+              <Text type="danger">{error}</Text>
+            </div>
+          )}
+
+          <section className="dashboard-stat-grid">
+            {reservationStats.map(stat => (
+              <Card key={stat.title} className="dashboard-stat-card" bordered={false}>
+                <Text className="stat-label">{stat.title}</Text>
+                <div className="stat-value-row">
+                  <Title level={2}>{stat.value}</Title>
+                  <Tag className={`stat-tag tag-${stat.badgeTone}`}>{stat.badge}</Tag>
+                </div>
+                <Text className="stat-helper">{stat.descriptor}</Text>
+              </Card>
+            ))}
+          </section>
+
+          <section className="dashboard-panels">
+            <Card className="dashboard-card" bordered={false}>
+              <div className="dashboard-card-header">
+                <div>
+                  <Text className="dashboard-card-eyebrow">Yaklaşan Rezervasyonlar</Text>
+                  <Title level={4}>Operasyon Akışı</Title>
+                </div>
+                <Tag icon={<TeamOutlined />} color="blue" className="dashboard-pill">
+                  {upcomingReservations.length} kayıt
+                </Tag>
+              </div>
+              <List
+                className="dashboard-reservation-list"
+                dataSource={upcomingReservations}
+                locale={{ emptyText: <Empty description="Yaklaşan rezervasyon bulunmuyor." /> }}
+                renderItem={item => {
+                  const customerName = [item.customer?.firstName, item.customer?.lastName].filter(Boolean).join(' ') || 'Müşteri';
+                  const serviceName = item.service?.name ?? 'Hizmet bilgisi yok';
+                  return (
+                    <List.Item key={item.id} className="dashboard-reservation-item">
+                      <List.Item.Meta avatar={<Avatar>{customerName.charAt(0)}</Avatar>} title={customerName} description={serviceName} />
+                      <div className="reservation-meta">
+                        <Text className="reservation-time">{dayjs(item.date).format('DD MMM YYYY HH:mm')}</Text>
+                        <Tag color={statusColors[item.status]} className="reservation-status">
+                          {statusLabels[item.status]}
+                        </Tag>
+                      </div>
+                    </List.Item>
+                  );
+                }}
+              />
+            </Card>
+
+            <Card className="dashboard-card" bordered={false}>
+              <div className="dashboard-card-header">
+                <div>
+                  <Text className="dashboard-card-eyebrow">Hizmet Dağılımı</Text>
+                  <Title level={4}>Talep Edilen Kategoriler</Title>
+                </div>
+                <Tag icon={<DollarCircleOutlined />} color="cyan" className="dashboard-pill">
+                  Toplam {reservations.length}
+                </Tag>
+              </div>
+              <div className="dashboard-occupancy">
+                {serviceDistribution.length > 0 ? (
+                  serviceDistribution.map(metric => (
+                    <div key={metric.label} className="occupancy-item">
+                      <div className="occupancy-label-row">
+                        <Text className="occupancy-label">{metric.label}</Text>
+                        <Text className="occupancy-value">%{metric.ratio}</Text>
+                      </div>
+                      <Progress
+                        percent={metric.ratio}
+                        size="small"
+                        strokeLinecap="round"
+                        strokeColor="#2563eb"
+                        trailColor="rgba(148, 163, 184, 0.15)"
+                      />
+                    </div>
+                  ))
+                ) : (
+                  <Empty description="Hizmet verisi bulunmuyor" image={Empty.PRESENTED_IMAGE_SIMPLE} />
+                )}
+              </div>
+              <div className="dashboard-revenue">
+                {revenueSummary.items.map(item => (
+                  <div key={item.key} className="revenue-item">
+                    <Text className="revenue-label">{item.label}</Text>
+                    <div className="revenue-value-group">
+                      <Text className="revenue-value">{currencyFormatter.format(item.amount)}</Text>
+                      <Tag className={`revenue-trend tag-${item.tone}`}>
+                        {item.tone === 'positive' ? '✓' : item.tone === 'negative' ? '↺' : '-'}
+                      </Tag>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </Card>
+          </section>
+        </>
+      )}
+    </main>
+  );
+};
+
+export default Dashboard;

--- a/frontend/src/pages/Dashboard/styles.css
+++ b/frontend/src/pages/Dashboard/styles.css
@@ -1,0 +1,327 @@
+.dashboard-page {
+  min-height: 100vh;
+  padding: clamp(24px, 4vw, 48px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(24px, 5vw, 40px);
+  background:
+    radial-gradient(circle at 12% 18%, rgba(37, 99, 235, 0.15), transparent 55%),
+    radial-gradient(circle at 88% 12%, rgba(56, 189, 248, 0.12), transparent 45%),
+    linear-gradient(160deg, rgba(255, 255, 255, 0.92), rgba(248, 250, 255, 0.75));
+}
+
+.dashboard-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: clamp(16px, 3vw, 48px);
+}
+
+.dashboard-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 12px;
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.55);
+  display: inline-block;
+  margin-bottom: 12px;
+}
+
+.dashboard-subtitle {
+  max-width: 560px;
+  color: rgba(30, 41, 59, 0.7);
+}
+
+.dashboard-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 16px;
+}
+
+.dashboard-range-picker,
+.dashboard-select {
+  border-radius: 12px !important;
+  background-color: rgba(255, 255, 255, 0.85);
+  box-shadow: 0 18px 40px -32px rgba(15, 23, 42, 0.35);
+  padding: 4px 10px;
+  border: 1px solid rgba(148, 163, 184, 0.2) !important;
+}
+
+.dashboard-select .ant-select-selector {
+  border-radius: 10px !important;
+  border: none !important;
+  background: transparent !important;
+  padding: 0 8px !important;
+  box-shadow: none !important;
+}
+
+.dashboard-select .ant-select-arrow {
+  color: var(--color-primary);
+}
+
+.dashboard-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: clamp(16px, 3vw, 28px);
+}
+
+.dashboard-stat-card {
+  border-radius: 18px;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.95), rgba(236, 245, 255, 0.85));
+  box-shadow: 0 30px 60px -48px rgba(15, 23, 42, 0.55);
+}
+
+.dashboard-stat-card .ant-card-body {
+  padding: 24px 26px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.stat-label {
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(71, 85, 105, 0.75);
+}
+
+.stat-value-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.stat-value-row h2.ant-typography {
+  margin: 0;
+  font-size: clamp(28px, 2.8vw, 36px);
+}
+
+.stat-tag {
+  border-radius: 999px;
+  border: none;
+  padding: 4px 12px;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.tag-positive {
+  color: #047857 !important;
+  background: rgba(16, 185, 129, 0.18) !important;
+}
+
+.tag-negative {
+  color: #be123c !important;
+  background: rgba(244, 63, 94, 0.18) !important;
+}
+
+.tag-warning {
+  color: #92400e !important;
+  background: rgba(251, 191, 36, 0.22) !important;
+}
+
+.tag-neutral {
+  color: rgba(15, 23, 42, 0.7) !important;
+  background: rgba(148, 163, 184, 0.18) !important;
+}
+
+.dashboard-loading {
+  min-height: 320px;
+  display: grid;
+  place-items: center;
+  background: rgba(255, 255, 255, 0.3);
+  border-radius: 24px;
+}
+
+.dashboard-error {
+  padding: 16px 24px;
+  border-radius: 16px;
+  background: rgba(248, 113, 113, 0.12);
+  border: 1px solid rgba(248, 113, 113, 0.25);
+  margin-bottom: 16px;
+}
+
+.stat-helper {
+  color: rgba(71, 85, 105, 0.75);
+}
+
+.dashboard-panels {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: clamp(20px, 4vw, 32px);
+}
+
+.dashboard-card {
+  border-radius: 22px;
+  background: linear-gradient(140deg, rgba(255, 255, 255, 0.94), rgba(241, 247, 255, 0.88));
+  box-shadow: 0 35px 60px -45px rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(16px);
+  overflow: hidden;
+}
+
+.dashboard-card .ant-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: clamp(24px, 4vw, 32px);
+}
+
+.dashboard-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.dashboard-card-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 12px;
+  font-weight: 600;
+  color: rgba(30, 41, 59, 0.55);
+}
+
+.dashboard-pill {
+  border-radius: 999px;
+  border: none;
+  padding: 4px 14px;
+  background: rgba(37, 99, 235, 0.1);
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+.dashboard-reservation-list .ant-list-item {
+  border-block-end: 1px solid rgba(148, 163, 184, 0.15);
+  padding: 16px 0;
+}
+
+.dashboard-reservation-list .ant-list-item:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.dashboard-reservation-item .ant-list-item-meta-title {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.dashboard-reservation-item .ant-list-item-meta-description {
+  color: rgba(71, 85, 105, 0.75);
+}
+
+.dashboard-reservation-item .ant-avatar {
+  background: linear-gradient(135deg, var(--color-primary), var(--color-accent));
+  font-weight: 600;
+}
+
+.reservation-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+}
+
+.reservation-time {
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.85);
+}
+
+.reservation-status {
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  padding-inline: 14px;
+  text-transform: capitalize;
+}
+
+.dashboard-occupancy {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.occupancy-item {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.occupancy-label-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: rgba(30, 41, 59, 0.8);
+}
+
+.occupancy-label {
+  font-weight: 600;
+}
+
+.occupancy-value {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.dashboard-divider {
+  margin: 4px 0;
+  border-top-color: rgba(148, 163, 184, 0.15);
+}
+
+.dashboard-revenue {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.revenue-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: rgba(71, 85, 105, 0.8);
+}
+
+.revenue-value-group {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.revenue-value {
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.revenue-trend {
+  border-radius: 999px;
+  border: none;
+}
+
+@media (max-width: 960px) {
+  .dashboard-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .dashboard-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 640px) {
+  .dashboard-page {
+    padding: 24px;
+  }
+
+  .dashboard-range-picker,
+  .dashboard-select {
+    width: 100%;
+  }
+
+  .dashboard-card {
+    border-radius: 18px;
+  }
+}

--- a/frontend/src/pages/Finance/index.tsx
+++ b/frontend/src/pages/Finance/index.tsx
@@ -1,0 +1,312 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Card, DatePicker, Empty, List, Progress, Select, Space, Spin, Tag, Typography } from 'antd';
+import { FundProjectionScreenOutlined, RiseOutlined, StockOutlined, WalletOutlined } from '@ant-design/icons';
+import dayjs from 'dayjs';
+import Topbar from '../../components/Topbar';
+import '../../styles/workspace.css';
+import './styles.css';
+import { paymentService, type Payment, type PaymentStatus } from '../../services/api';
+
+const { RangePicker } = DatePicker;
+const { Title, Text } = Typography;
+
+const currencyFormatter = new Intl.NumberFormat('tr-TR', {
+  style: 'currency',
+  currency: 'TRY',
+  maximumFractionDigits: 0,
+});
+
+const statusLabels: Record<PaymentStatus, string> = {
+  PENDING: 'Beklemede',
+  PAID: 'Tamamlandı',
+  FAILED: 'Başarısız',
+  REFUNDED: 'İade edildi',
+};
+
+const Finance: React.FC = () => {
+  const [payments, setPayments] = useState<Payment[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchFinanceData = async () => {
+      try {
+        const paymentResponse = await paymentService.list({ page: 0, size: 200, sort: 'id,desc' });
+
+        if (!isMounted) {
+          return;
+        }
+
+        setPayments(paymentResponse.items);
+      } catch {
+        if (isMounted) {
+          setError('Finans verileri alınamadı.');
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchFinanceData();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const paidTotal = useMemo(
+    () => payments.filter(payment => payment.status === 'PAID').reduce((total, payment) => total + Number(payment.amount ?? 0), 0),
+    [payments],
+  );
+  const pendingTotal = useMemo(
+    () => payments.filter(payment => payment.status === 'PENDING').reduce((total, payment) => total + Number(payment.amount ?? 0), 0),
+    [payments],
+  );
+  const refundedTotal = useMemo(
+    () => payments.filter(payment => payment.status === 'REFUNDED').reduce((total, payment) => total + Number(payment.amount ?? 0), 0),
+    [payments],
+  );
+  const averagePayment = useMemo(() => (payments.length ? paidTotal / payments.length : 0), [payments, paidTotal]);
+  const totalRevenue = paidTotal + pendingTotal + refundedTotal;
+
+  const financeHighlights = [
+    {
+      title: 'Tahsil Edilen',
+      value: currencyFormatter.format(paidTotal),
+      helper: `${payments.filter(payment => payment.status === 'PAID').length} işlem`,
+      progress: totalRevenue ? Math.round((paidTotal / totalRevenue) * 100) : 0,
+      accent: '#2563eb',
+      icon: <WalletOutlined />,
+    },
+    {
+      title: 'Bekleyen Tahsilat',
+      value: currencyFormatter.format(pendingTotal),
+      helper: `${payments.filter(payment => payment.status === 'PENDING').length} işlem`,
+      progress: totalRevenue ? Math.round((pendingTotal / totalRevenue) * 100) : 0,
+      accent: '#f97316',
+      icon: <StockOutlined />,
+    },
+    {
+      title: 'İade Edilen',
+      value: currencyFormatter.format(refundedTotal),
+      helper: `${payments.filter(payment => payment.status === 'REFUNDED').length} işlem`,
+      progress: totalRevenue ? Math.round((refundedTotal / totalRevenue) * 100) : 0,
+      accent: '#a855f7',
+      icon: <FundProjectionScreenOutlined />,
+    },
+    {
+      title: 'Ortalama İşlem',
+      value: currencyFormatter.format(averagePayment || 0),
+      helper: `${payments.length} ödeme kaydı`,
+      progress: payments.length ? Math.min(100, Math.round((averagePayment / (paidTotal || 1)) * 100)) : 0,
+      accent: '#10b981',
+      icon: <RiseOutlined />,
+    },
+  ];
+
+  const paymentMethodDistribution = useMemo(() => {
+    const counts = payments.reduce<Record<string, number>>((acc, payment) => {
+      const method = payment.method ?? 'Bilinmiyor';
+      acc[method] = (acc[method] ?? 0) + 1;
+      return acc;
+    }, {});
+
+    return Object.entries(counts)
+      .map(([method, count]) => ({ method, count, ratio: Math.round((count / (payments.length || 1)) * 100) }))
+      .sort((a, b) => b.count - a.count);
+  }, [payments]);
+
+  const latestPayments = useMemo(() => {
+    return payments.slice(0, 6).map(payment => {
+      const customerName = [payment.customer?.firstName, payment.customer?.lastName].filter(Boolean).join(' ') || 'Müşteri';
+      const reservationDate = payment.reservation?.date ? dayjs(payment.reservation.date).format('DD MMM YYYY') : 'Tarih yok';
+      return {
+        ...payment,
+        customerName,
+        reservationDate,
+      };
+    });
+  }, [payments]);
+
+  const outstandingPayments = useMemo(() => {
+    return payments
+      .filter(payment => payment.status === 'PENDING' || payment.status === 'FAILED')
+      .sort((a, b) => Number(b.amount ?? 0) - Number(a.amount ?? 0))
+      .slice(0, 5)
+      .map(payment => {
+        const customerName = [payment.customer?.firstName, payment.customer?.lastName].filter(Boolean).join(' ') || 'Müşteri';
+        return {
+          id: payment.id,
+          customerName,
+          amount: Number(payment.amount ?? 0),
+          due: payment.reservation?.date ? dayjs(payment.reservation.date).format('DD MMM YYYY HH:mm') : 'Planlanmadı',
+          method: payment.method,
+          status: payment.status,
+        };
+      });
+  }, [payments]);
+
+  return (
+    <main className="workspace-page finance-page">
+      <Topbar />
+      <header className="workspace-header">
+        <div>
+          <Text className="workspace-eyebrow">Gelir Optimizasyonu</Text>
+          <Title level={2}>Finans Performans Panosu</Title>
+          <Text className="workspace-subtitle">
+            Gelir kaynaklarını analiz edin, masraf trendlerini izleyin ve nakit akışınızı sürdürülebilir büyüme için planlayın.
+          </Text>
+        </div>
+        <Space size={16} className="workspace-actions" wrap>
+          <RangePicker />
+          <Select
+            defaultValue="month"
+            options={[
+              { label: 'Bu Ay', value: 'month' },
+              { label: 'Bu Çeyrek', value: 'quarter' },
+              { label: 'Bu Yıl', value: 'year' },
+            ]}
+          />
+        </Space>
+      </header>
+
+      {loading ? (
+        <div className="workspace-loader">
+          <Spin size="large" />
+        </div>
+      ) : (
+        <>
+          {error && (
+            <div className="workspace-error">
+              <Text type="danger">{error}</Text>
+            </div>
+          )}
+
+          <section className="workspace-section finance-overview">
+            <div className="workspace-stat-grid">
+              {financeHighlights.map(highlight => (
+                <Card key={highlight.title} className="workspace-stat-card" bordered={false}>
+                  <Text className="workspace-stat-label">{highlight.title}</Text>
+                  <div className="finance-stat-value">
+                    <div className="finance-value-row">
+                      <Title level={3}>{highlight.value}</Title>
+                      <span className="finance-icon">{highlight.icon}</span>
+                    </div>
+                    <span className="finance-helper" style={{ color: highlight.accent }}>
+                      {highlight.helper}
+                    </span>
+                  </div>
+                  <Progress
+                    percent={Math.min(100, highlight.progress)}
+                    strokeColor={highlight.accent}
+                    trailColor="rgba(148, 163, 184, 0.18)"
+                    strokeLinecap="round"
+                  />
+                </Card>
+              ))}
+            </div>
+          </section>
+
+          <section className="workspace-section finance-grid">
+            <Card className="workspace-card finance-revenue-card" bordered={false}>
+              <div className="workspace-card-header">
+                <div>
+                  <Text className="workspace-stat-label">Ödeme Hareketleri</Text>
+                  <Title level={4}>En Son Tahsilatlar</Title>
+                </div>
+                <Tag icon={<RiseOutlined />} className="workspace-pill">
+                  {payments.length} kayıt
+                </Tag>
+              </div>
+              <List
+                className="finance-revenue-list"
+                dataSource={latestPayments}
+                locale={{ emptyText: <Empty description="Ödeme kaydı bulunamadı." /> }}
+                renderItem={payment => (
+                  <List.Item className="finance-revenue-item" key={payment.id}>
+                    <div className="finance-revenue-copy">
+                      <Text className="finance-revenue-label">{payment.customerName}</Text>
+                      <Text className="finance-revenue-value">{currencyFormatter.format(Number(payment.amount ?? 0))}</Text>
+                    </div>
+                    <div className="finance-revenue-meta">
+                      <Tag color="blue" className="finance-revenue-tag">
+                        {payment.method ?? 'Bilinmiyor'}
+                      </Tag>
+                      <Tag
+                        color={payment.status === 'PAID' ? 'green' : payment.status === 'PENDING' ? 'orange' : 'red'}
+                        className="finance-revenue-tag"
+                      >
+                        {statusLabels[payment.status]}
+                      </Tag>
+                      <Text className="finance-revenue-time">{payment.reservationDate}</Text>
+                    </div>
+                  </List.Item>
+                )}
+              />
+            </Card>
+
+            <Card className="workspace-card finance-insights-card" bordered={false}>
+              <div className="workspace-card-header">
+                <div>
+                  <Text className="workspace-stat-label">Ödeme Yöntemi Dağılımı</Text>
+                  <Title level={4}>Tahsilat Kanalları</Title>
+                </div>
+                <Tag icon={<StockOutlined />} className="workspace-pill">
+                  {paymentMethodDistribution.length} yöntem
+                </Tag>
+              </div>
+              <div className="finance-methods">
+                {paymentMethodDistribution.length > 0 ? (
+                  paymentMethodDistribution.map(method => (
+                    <div key={method.method} className="finance-method-item">
+                      <div className="finance-method-header">
+                        <Text className="finance-method-name">{method.method}</Text>
+                        <Text className="finance-method-value">%{method.ratio}</Text>
+                      </div>
+                      <Progress percent={method.ratio} strokeColor="#2563eb" trailColor="rgba(148, 163, 184, 0.18)" strokeLinecap="round" />
+                    </div>
+                  ))
+                ) : (
+                  <Empty description="Ödeme yöntemi verisi bulunamadı." image={Empty.PRESENTED_IMAGE_SIMPLE} />
+                )}
+              </div>
+
+              <div className="finance-collections">
+                <div className="finance-collections-header">
+                  <Text className="workspace-stat-label">Takip Gerektiren İşlemler</Text>
+                  <Tag icon={<WalletOutlined />} className="workspace-pill">
+                    {outstandingPayments.length} kayıt
+                  </Tag>
+                </div>
+                <List
+                  dataSource={outstandingPayments}
+                  locale={{ emptyText: <Empty description="Bekleyen işlem bulunmuyor." /> }}
+                  renderItem={item => (
+                    <List.Item key={item.id} className="finance-collection-item">
+                      <div className="finance-collection-main">
+                        <Text className="finance-collection-name">{item.customerName}</Text>
+                        <Text className="finance-collection-due">{item.due}</Text>
+                      </div>
+                      <div className="finance-collection-meta">
+                        <Tag color="orange" className="finance-collection-tag">
+                          {item.method ?? 'Bilinmiyor'}
+                        </Tag>
+                        <Text className="finance-collection-amount">{currencyFormatter.format(item.amount)}</Text>
+                      </div>
+                    </List.Item>
+                  )}
+                />
+              </div>
+            </Card>
+          </section>
+        </>
+      )}
+    </main>
+  );
+};
+
+export default Finance;

--- a/frontend/src/pages/Finance/styles.css
+++ b/frontend/src/pages/Finance/styles.css
@@ -1,0 +1,192 @@
+.finance-page .workspace-stat-card .ant-card-body {
+  gap: 16px;
+}
+
+.finance-stat-value {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.finance-value-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.finance-stat-value h3.ant-typography {
+  margin: 0;
+  font-size: clamp(26px, 2.6vw, 32px);
+}
+
+.finance-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  background: rgba(37, 99, 235, 0.08);
+  color: rgba(37, 99, 235, 0.9);
+  font-size: 18px;
+}
+
+.finance-helper {
+  font-weight: 600;
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.04);
+  border: 1px solid currentColor;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.45);
+}
+
+.finance-grid {
+  grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+}
+
+.finance-revenue-list,
+.finance-methods,
+.finance-collections {
+  margin-top: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.finance-revenue-item,
+.finance-collection-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.78);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  box-shadow: 0 20px 45px -38px rgba(15, 23, 42, 0.4);
+}
+
+.finance-revenue-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.finance-revenue-label {
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.82);
+}
+
+.finance-revenue-value {
+  font-weight: 700;
+  color: rgba(15, 23, 42, 0.85);
+}
+
+.finance-revenue-meta,
+.finance-collection-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: flex-end;
+}
+
+.finance-revenue-tag.ant-tag,
+.finance-collection-tag.ant-tag {
+  border-radius: 999px;
+  padding: 2px 12px;
+  font-weight: 600;
+  border: none;
+}
+
+.finance-method-item {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.finance-method-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.finance-method-name {
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.85);
+}
+
+.finance-method-value {
+  font-weight: 600;
+  color: rgba(71, 85, 105, 0.75);
+}
+
+.finance-collections {
+  margin-top: 28px;
+}
+
+.finance-collections-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.finance-collection-main {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.finance-collection-name {
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.85);
+}
+
+.finance-collection-due {
+  color: rgba(71, 85, 105, 0.75);
+}
+
+.finance-revenue-time {
+  color: rgba(71, 85, 105, 0.65);
+}
+
+.finance-collection-copy h5.ant-typography {
+  margin: 0;
+}
+
+.finance-collection-copy span,
+.finance-collection-copy .ant-typography {
+  color: rgba(71, 85, 105, 0.75);
+}
+
+.finance-collection-amount {
+  font-weight: 700;
+  color: rgba(15, 23, 42, 0.85);
+}
+
+@media (max-width: 960px) {
+  .finance-revenue-item,
+  .finance-collection-item {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .finance-revenue-meta,
+  .finance-collection-meta {
+    align-items: flex-start;
+    width: 100%;
+  }
+}
+
+@media (max-width: 640px) {
+  .finance-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .finance-stat-value {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/frontend/src/pages/Login/index.tsx
+++ b/frontend/src/pages/Login/index.tsx
@@ -1,10 +1,11 @@
-import React, {useState} from 'react';
-import {Form, Input, Button, Checkbox, Card, Typography, message, Alert} from 'antd';
-import {UserOutlined, LockOutlined} from '@ant-design/icons';
-import {authService} from '../../services/api';
+import React, { useState } from 'react';
+import { Form, Input, Button, Checkbox, Card, Typography, message, Alert } from 'antd';
+import { UserOutlined, LockOutlined } from '@ant-design/icons';
+import axios from 'axios';
+import { authService } from '../../services/api';
 import './styles.css';
 
-const {Title, Text} = Typography;
+const { Title, Text } = Typography;
 
 interface LoginFormValues {
   username: string;
@@ -26,17 +27,15 @@ const Login: React.FC = () => {
       await form.validateFields();
 
       // Backend bağlantısı
-      const response = await authService.login(values.username, values.password);
+      const token = await authService.login(values.username, values.password, values.remember);
 
-      if (response.data) {
-        // Başarılı giriş
-        localStorage.setItem('token', response.data.token);
+      if (token) {
+        localStorage.setItem('token', token);
         message.success('Giriş başarılı!');
-        // Ana sayfaya yönlendirme
         window.location.href = '/dashboard';
       }
-    } catch (error: any) {
-      if (error.isAxiosError) {
+    } catch (error: unknown) {
+      if (axios.isAxiosError(error)) {
         // API hatası
         if (error.response?.status === 401) {
           setError('Kullanıcı adı veya şifre hatalı!');
@@ -47,6 +46,8 @@ const Login: React.FC = () => {
         } else {
           setError('Bir hata oluştu. Lütfen daha sonra tekrar deneyin.');
         }
+      } else {
+        setError('Bir hata oluştu. Lütfen daha sonra tekrar deneyin.');
       }
       message.error('Giriş başarısız!');
     } finally {
@@ -70,47 +71,32 @@ const Login: React.FC = () => {
             showIcon
             closable
             className="login-error"
-            style={{marginBottom: 24}}
+            style={{ marginBottom: 24 }}
           />
         )}
 
-        <Form
-          name="login"
-          className="login-form"
-          initialValues={{remember: true}}
-          onFinish={onFinish}
-          form={form}
-        >
+        <Form name="login" className="login-form" initialValues={{ remember: true }} onFinish={onFinish} form={form}>
           <Form.Item
             name="username"
             rules={[
-              {required: true, message: 'Lütfen kullanıcı adınızı girin!'},
-              {min: 3, message: 'Kullanıcı adı en az 3 karakter olmalıdır!'},
-              {max: 50, message: 'Kullanıcı adı en fazla 50 karakter olabilir!'}
+              { required: true, message: 'Lütfen kullanıcı adınızı girin!' },
+              { min: 3, message: 'Kullanıcı adı en az 3 karakter olmalıdır!' },
+              { max: 50, message: 'Kullanıcı adı en fazla 50 karakter olabilir!' },
             ]}
           >
-            <Input
-              prefix={<UserOutlined/>}
-              placeholder="Kullanıcı Adı"
-              size="large"
-            />
+            <Input prefix={<UserOutlined />} placeholder="Kullanıcı Adı" size="large" />
           </Form.Item>
 
           <Form.Item
             name="password"
             rules={[
-              {required: true, message: 'Lütfen şifrenizi girin!'},
+              { required: true, message: 'Lütfen şifrenizi girin!' },
               {
-                message: 'Şifre en az bir harf ve bir rakam içermelidir!'
-              }
+                message: 'Şifre en az bir harf ve bir rakam içermelidir!',
+              },
             ]}
           >
-            <Input
-              prefix={<LockOutlined/>}
-              type="password"
-              placeholder="Şifre"
-              size="large"
-            />
+            <Input prefix={<LockOutlined />} type="password" placeholder="Şifre" size="large" />
           </Form.Item>
 
           <Form.Item>
@@ -126,13 +112,7 @@ const Login: React.FC = () => {
           </Form.Item>
 
           <Form.Item>
-            <Button
-              type="primary"
-              htmlType="submit"
-              className="login-form-button"
-              loading={loading}
-              block
-            >
+            <Button type="primary" htmlType="submit" className="login-form-button" loading={loading} block>
               Giriş Yap
             </Button>
           </Form.Item>

--- a/frontend/src/pages/Login/styles.css
+++ b/frontend/src/pages/Login/styles.css
@@ -1,148 +1,147 @@
 .login-container {
+  position: relative;
   display: flex;
-  justify-content: center;
   align-items: center;
+  justify-content: center;
   min-height: 100vh;
-  background-color: #f5f5f5;
+  padding: 64px 24px 48px;
+}
+
+.login-container::before,
+.login-container::after {
+  content: '';
+  position: absolute;
+  border-radius: 999px;
+  filter: blur(45px);
+  opacity: 0.55;
+  z-index: 0;
+}
+
+.login-container::before {
+  width: 420px;
+  height: 420px;
+  background: radial-gradient(circle at center, rgba(37, 99, 235, 0.38), transparent 65%);
+  top: 10%;
+  left: clamp(-120px, 10vw, -60px);
+}
+
+.login-container::after {
+  width: 360px;
+  height: 360px;
+  background: radial-gradient(circle at center, rgba(56, 189, 248, 0.28), transparent 60%);
+  bottom: 10%;
+  right: clamp(-140px, 12vw, -40px);
 }
 
 .login-card {
-  width: 400px;
-  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
-  border-radius: 12px;
-  overflow: hidden;
-  background-color: white;
-  animation: fadeIn 0.8s ease-in-out;
-  transform-origin: center;
+  position: relative;
+  z-index: 1;
+  width: min(420px, 100%);
 }
 
-.login-card {
-  backdrop-filter: blur(12px);
-  background: rgba(255, 255, 255, 0.9);
-}
-
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-    transform: translateY(20px) scale(0.98);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
+.login-card .ant-card-body {
+  padding: 40px 36px 44px;
+  display: flex;
+  flex-direction: column;
 }
 
 .login-header {
   text-align: center;
-  margin-bottom: 28px;
-  padding-top: 10px;
+  margin-bottom: 32px;
 }
 
 .login-header h2 {
-  margin-bottom: 8px;
-  font-weight: 600;
-  color: #333;
-  animation: slideDown 0.6s ease-out;
+  margin-bottom: 12px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
 }
 
-@keyframes slideDown {
-  from {
-    opacity: 0;
-    transform: translateY(-15px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+.login-header .ant-typography {
+  color: var(--color-muted);
+  font-size: 15px;
+}
+
+.login-error {
+  margin-bottom: 24px !important;
 }
 
 .login-form {
-  margin-top: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.ant-form-item {
+  margin-bottom: 12px;
 }
 
 .login-options {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 12px;
+  margin-top: -4px;
+  flex-wrap: wrap;
 }
 
 .login-form-forgot {
-  float: right;
-  color: #1890ff;
-  transition: color 0.3s;
+  color: var(--color-primary);
+  font-weight: 600;
 }
 
 .login-form-forgot:hover {
-  color: #40a9ff;
   text-decoration: underline;
 }
 
 .login-form-button {
-  height: 44px;
+  height: 48px;
   font-size: 16px;
-  margin-top: 20px;
-  border-radius: 6px;
-  background: linear-gradient(90deg, #1890ff, #40a9ff);
-  border: none;
-  box-shadow: 0 4px 12px rgba(24, 144, 255, 0.3);
-  transition: all 0.3s ease;
+  border-radius: 14px;
 }
 
-.login-form-button:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 6px 16px rgba(24, 144, 255, 0.4);
-  background: linear-gradient(90deg, #40a9ff, #1890ff);
+.login-form-button .ant-btn-loading-icon {
+  transform: translateY(-1px);
 }
 
-.login-form-button:active {
-  transform: translateY(1px);
+.login-footer {
+  margin-top: 28px;
+  text-align: center;
+  color: var(--color-muted);
+  font-size: 14px;
 }
 
-/* Form alanları için özel stiller */
-.ant-input-affix-wrapper {
-  border-radius: 6px;
-  border: 1px solid #e8e8e8;
-  transition: all 0.3s;
-  height: 44px;
-  margin-bottom: 5px;
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.02);
+.login-footer strong {
+  color: #0f172a;
 }
 
-.ant-input-affix-wrapper:hover,
-.ant-input-affix-wrapper:focus {
-  border-color: #40a9ff;
-  box-shadow: 0 0 0 2px rgba(24, 144, 255, 0.2);
-}
-
-.ant-form-item {
-  margin-bottom: 20px;
-  opacity: 0;
-  animation: fadeInUp 0.5s ease forwards;
-}
-
-.ant-form-item:nth-child(1) {
-  animation-delay: 0.2s;
-}
-
-.ant-form-item:nth-child(2) {
-  animation-delay: 0.4s;
-}
-
-.ant-form-item:nth-child(3) {
-  animation-delay: 0.6s;
-}
-
-.ant-form-item:nth-child(4) {
-  animation-delay: 0.8s;
-}
-
-@keyframes fadeInUp {
-  from {
-    opacity: 0;
-    transform: translateY(10px);
+@media (max-width: 640px) {
+  .login-container {
+    padding-top: 48px;
   }
-  to {
-    opacity: 1;
-    transform: translateY(0);
+
+  .login-card {
+    width: min(100%, 360px);
+  }
+
+  .login-card .ant-card-body {
+    padding: 32px 24px 36px;
+  }
+
+  .login-header h2 {
+    font-size: 24px;
+  }
+
+  .login-header .ant-typography {
+    font-size: 14px;
+  }
+
+  .login-options {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .login-form-forgot {
+    align-self: flex-start;
   }
 }

--- a/frontend/src/pages/Profile/index.tsx
+++ b/frontend/src/pages/Profile/index.tsx
@@ -1,0 +1,261 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Avatar, Button, Card, Col, Divider, Form, Input, Row, Space, Spin, Typography, Upload, message } from 'antd';
+import type { UploadProps } from 'antd';
+import { ArrowLeftOutlined, CameraOutlined, LockOutlined, MailOutlined, UserOutlined } from '@ant-design/icons';
+import axios from 'axios';
+import { accountService, type AdminUser } from '../../services/api';
+import './styles.css';
+
+const { Title, Text } = Typography;
+
+const initialAvatar = 'https://images.unsplash.com/photo-1544723795-3fb6469f5b39?auto=format&fit=crop&w=320&q=80';
+
+const Profile: React.FC = () => {
+  const navigate = useNavigate();
+  const [avatarUrl, setAvatarUrl] = useState<string>(initialAvatar);
+  const [account, setAccount] = useState<AdminUser | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleBack = () => {
+    if (window.history.length > 1) {
+      navigate(-1);
+    } else {
+      navigate('/dashboard');
+    }
+  };
+  const [form] = Form.useForm();
+  const [messageApi, contextHolder] = message.useMessage();
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadAccount = async () => {
+      try {
+        const response = await accountService.getProfile();
+        if (!isMounted) {
+          return;
+        }
+        setAccount(response.data);
+        const imageUrl = response.data.imageUrl || initialAvatar;
+        setAvatarUrl(imageUrl);
+        form.setFieldsValue({
+          firstName: response.data.firstName,
+          lastName: response.data.lastName,
+          email: response.data.email,
+        });
+      } catch (error) {
+        if (axios.isAxiosError(error)) {
+          messageApi.error('Profil bilgileri alınamadı. Lütfen oturum durumunuzu kontrol edin.');
+        } else {
+          messageApi.error('Profil verileri yüklenirken bir hata oluştu.');
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    loadAccount();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [form, messageApi]);
+
+  const handleAvatarUpload: UploadProps['beforeUpload'] = file => {
+    const isImage = file.type.startsWith('image/');
+    if (!isImage) {
+      messageApi.error('Lütfen geçerli bir görsel dosyası seçin.');
+      return Upload.LIST_IGNORE;
+    }
+
+    const isLt2M = file.size / 1024 / 1024 < 2;
+    if (!isLt2M) {
+      messageApi.error('Profil fotoğrafı 2MB boyutunu geçmemelidir.');
+      return Upload.LIST_IGNORE;
+    }
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      setAvatarUrl(reader.result as string);
+      setAccount(prev => (prev ? { ...prev, imageUrl: reader.result as string } : prev));
+    };
+    reader.readAsDataURL(file);
+
+    return false;
+  };
+
+  const handleFormFinish = async (values: Record<string, string>) => {
+    if (!account) {
+      return;
+    }
+
+    try {
+      setSubmitting(true);
+      const payload: AdminUser = {
+        ...account,
+        firstName: values.firstName,
+        lastName: values.lastName,
+        email: values.email,
+        imageUrl: avatarUrl,
+        langKey: account.langKey ?? 'tr',
+      };
+
+      await accountService.updateProfile(payload);
+      setAccount(payload);
+      messageApi.success('Profil ayarlarınız başarıyla güncellendi.');
+
+      if (values.currentPassword && values.newPassword) {
+        await accountService.changePassword(values.currentPassword, values.newPassword);
+        messageApi.success('Şifreniz güncellendi.');
+      }
+
+      form.resetFields(['currentPassword', 'newPassword', 'confirmPassword']);
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        const responseMessage = error.response?.data?.message;
+        messageApi.error(responseMessage || 'Profil güncellenirken bir hata oluştu.');
+      } else {
+        messageApi.error('Profil güncellenirken bir hata oluştu.');
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const passwordRules = [
+    { required: true, message: 'Bu alan zorunludur.' },
+    {
+      min: 8,
+      message: 'Şifre en az 8 karakter olmalıdır.',
+    },
+  ];
+
+  return (
+    <main className="profile-page">
+      {contextHolder}
+      <div className="profile-toolbar">
+        <Button type="link" icon={<ArrowLeftOutlined />} onClick={handleBack} className="profile-back-button">
+          Önceki sayfaya dön
+        </Button>
+      </div>
+      <Card className="profile-card" bordered={false}>
+        {loading ? (
+          <div className="profile-loading">
+            <Spin size="large" />
+          </div>
+        ) : (
+          <>
+            <div className="profile-header">
+              <div className="profile-heading">
+                <Text className="profile-eyebrow">Hesap Yönetimi</Text>
+                <Title level={2}>Profilinizi Düzenleyin</Title>
+                <Text className="profile-subtitle">
+                  İletişim bilgilerinizi güncelleyin, güçlü bir şifre belirleyin ve profesyonel bir profil fotoğrafı yükleyin.
+                </Text>
+              </div>
+              <div className="profile-avatar-wrapper">
+                <div className="profile-avatar-frame">
+                  <Avatar src={avatarUrl} size={96} icon={<UserOutlined />} alt="Kullanıcı profil fotoğrafı" />
+                  <Upload accept="image/*" showUploadList={false} beforeUpload={handleAvatarUpload} className="profile-avatar-upload">
+                    <Button type="primary" shape="circle" icon={<CameraOutlined />} aria-label="Profil fotoğrafı yükle" />
+                  </Upload>
+                </div>
+                <Text className="profile-avatar-hint">PNG, JPG veya WEBP formatı · Maksimum 2MB</Text>
+              </div>
+            </div>
+
+            <Divider className="profile-divider" />
+
+            <Form layout="vertical" form={form} onFinish={handleFormFinish} className="profile-form">
+              <Row gutter={[24, 24]}>
+                <Col xs={24} md={12}>
+                  <Form.Item label="Ad" name="firstName" rules={[{ required: true, message: 'Lütfen adınızı girin.' }]}>
+                    <Input prefix={<UserOutlined />} placeholder="Adınız" size="large" />
+                  </Form.Item>
+                </Col>
+                <Col xs={24} md={12}>
+                  <Form.Item label="Soyad" name="lastName" rules={[{ required: true, message: 'Lütfen soyadınızı girin.' }]}>
+                    <Input prefix={<UserOutlined />} placeholder="Soyadınız" size="large" />
+                  </Form.Item>
+                </Col>
+                <Col xs={24} md={12}>
+                  <Form.Item
+                    label="E-posta"
+                    name="email"
+                    rules={[
+                      { required: true, message: 'Lütfen bir e-posta adresi girin.' },
+                      { type: 'email', message: 'Geçerli bir e-posta adresi girin.' },
+                    ]}
+                  >
+                    <Input prefix={<MailOutlined />} placeholder="ornek@domain.com" size="large" />
+                  </Form.Item>
+                </Col>
+              </Row>
+
+              <section className="profile-section">
+                <div className="profile-section-header">
+                  <Title level={4}>Şifre Yönetimi</Title>
+                  <Text>Güvenliğinizi artırmak için güçlü ve benzersiz bir şifre belirleyin.</Text>
+                </div>
+                <Row gutter={[24, 24]}>
+                  <Col xs={24} md={12}>
+                    <Form.Item label="Mevcut Şifre" name="currentPassword" rules={passwordRules}>
+                      <Input.Password prefix={<LockOutlined />} placeholder="Mevcut şifreniz" size="large" />
+                    </Form.Item>
+                  </Col>
+                  <Col xs={24} md={12}>
+                    <Form.Item label="Yeni Şifre" name="newPassword" rules={passwordRules} hasFeedback>
+                      <Input.Password prefix={<LockOutlined />} placeholder="Yeni şifrenizi oluşturun" size="large" />
+                    </Form.Item>
+                  </Col>
+                  <Col xs={24} md={12}>
+                    <Form.Item
+                      label="Yeni Şifre (Tekrar)"
+                      name="confirmPassword"
+                      dependencies={['newPassword']}
+                      hasFeedback
+                      rules={[
+                        { required: true, message: 'Lütfen yeni şifrenizi tekrar girin.' },
+                        ({ getFieldValue }) => ({
+                          validator(_, value) {
+                            if (!value || getFieldValue('newPassword') === value) {
+                              return Promise.resolve();
+                            }
+                            return Promise.reject(new Error('Şifreler eşleşmiyor.'));
+                          },
+                        }),
+                      ]}
+                    >
+                      <Input.Password prefix={<LockOutlined />} placeholder="Yeni şifrenizi tekrar girin" size="large" />
+                    </Form.Item>
+                  </Col>
+                </Row>
+              </section>
+
+              <div className="profile-form-actions">
+                <Space size={16} wrap>
+                  <Button type="primary" htmlType="submit" size="large" loading={submitting}>
+                    Değişiklikleri Kaydet
+                  </Button>
+                  <Button
+                    size="large"
+                    onClick={() => form.resetFields(['currentPassword', 'newPassword', 'confirmPassword'])}
+                    disabled={submitting}
+                  >
+                    Şifre Alanlarını Temizle
+                  </Button>
+                </Space>
+              </div>
+            </Form>
+          </>
+        )}
+      </Card>
+    </main>
+  );
+};
+
+export default Profile;

--- a/frontend/src/pages/Profile/styles.css
+++ b/frontend/src/pages/Profile/styles.css
@@ -1,0 +1,209 @@
+.profile-page {
+  min-height: 100vh;
+  padding: clamp(32px, 5vw, 64px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+  background:
+    radial-gradient(circle at 12% 18%, rgba(37, 99, 235, 0.14), transparent 55%),
+    radial-gradient(circle at 88% 12%, rgba(56, 189, 248, 0.12), transparent 45%),
+    linear-gradient(155deg, rgba(255, 255, 255, 0.92), rgba(236, 244, 255, 0.75));
+}
+
+.profile-card {
+  width: min(960px, 100%);
+  border-radius: 28px;
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.96), rgba(241, 246, 255, 0.9));
+  box-shadow: 0 40px 80px -60px rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(22px);
+}
+
+.profile-card .ant-card-body {
+  padding: clamp(32px, 5vw, 52px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(28px, 5vw, 40px);
+}
+
+.profile-loading {
+  min-height: 320px;
+  display: grid;
+  place-items: center;
+}
+
+.profile-toolbar {
+  width: min(960px, 100%);
+  display: flex;
+  justify-content: flex-start;
+}
+
+.profile-back-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(37, 99, 235, 0.18);
+  background: rgba(37, 99, 235, 0.08);
+  font-weight: 600;
+  color: var(--color-primary);
+  text-decoration: none;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease,
+    color 0.2s ease;
+}
+
+.profile-back-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 40px -30px rgba(37, 99, 235, 0.45);
+  color: var(--color-primary);
+}
+
+.profile-back-button .anticon {
+  font-size: 16px;
+}
+
+.profile-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: clamp(24px, 4vw, 48px);
+}
+
+.profile-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-width: 520px;
+}
+
+.profile-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 12px;
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.55);
+}
+
+.profile-subtitle {
+  color: rgba(30, 41, 59, 0.7);
+}
+
+.profile-avatar-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  text-align: center;
+}
+
+.profile-avatar-frame {
+  position: relative;
+  display: grid;
+  place-items: center;
+}
+
+.profile-avatar-frame .ant-avatar {
+  border: 6px solid rgba(255, 255, 255, 0.65);
+  box-shadow: 0 30px 60px -40px rgba(15, 23, 42, 0.45);
+}
+
+.profile-avatar-upload .ant-btn {
+  position: absolute;
+  bottom: -6px;
+  right: -6px;
+  width: 44px;
+  height: 44px;
+  display: grid;
+  place-items: center;
+  box-shadow: 0 20px 45px -30px rgba(37, 99, 235, 0.6);
+}
+
+.profile-avatar-hint {
+  font-size: 13px;
+  color: rgba(71, 85, 105, 0.75);
+}
+
+.profile-divider {
+  margin: 0;
+  border-top-color: rgba(148, 163, 184, 0.18);
+}
+
+.profile-form .ant-form-item-label > label {
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.85);
+}
+
+.profile-section {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 24px;
+  border-radius: 20px;
+  background: linear-gradient(150deg, rgba(37, 99, 235, 0.05), rgba(56, 189, 248, 0.08));
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.profile-section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.profile-section-header .ant-typography,
+.profile-section-header span {
+  color: rgba(15, 23, 42, 0.82);
+}
+
+.profile-form-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.profile-form-actions .ant-space {
+  justify-content: flex-end;
+}
+
+.profile-form-actions .ant-btn-default {
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(255, 255, 255, 0.85);
+  font-weight: 600;
+}
+
+@media (max-width: 992px) {
+  .profile-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .profile-avatar-wrapper {
+    align-items: flex-start;
+    text-align: left;
+  }
+
+  .profile-form-actions {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 640px) {
+  .profile-page {
+    padding: 24px;
+  }
+
+  .profile-card .ant-card-body {
+    padding: 24px;
+  }
+
+  .profile-section {
+    padding: 20px;
+  }
+
+  .profile-form-actions {
+    justify-content: center;
+  }
+}

--- a/frontend/src/pages/Reservations/index.tsx
+++ b/frontend/src/pages/Reservations/index.tsx
@@ -1,0 +1,400 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Avatar,
+  Button,
+  Card,
+  DatePicker,
+  Empty,
+  Form,
+  Input,
+  List,
+  Modal,
+  Progress,
+  Select,
+  Space,
+  Spin,
+  Tag,
+  Timeline,
+  Typography,
+  message,
+} from 'antd';
+import { CalendarOutlined, ClockCircleOutlined, LineChartOutlined, ThunderboltOutlined } from '@ant-design/icons';
+import dayjs from 'dayjs';
+import type { Dayjs } from 'dayjs';
+import Topbar from '../../components/Topbar';
+import '../../styles/workspace.css';
+import './styles.css';
+import { reservationService, type Reservation, type ReservationStatus } from '../../services/api';
+
+const { RangePicker } = DatePicker;
+const { Title, Text } = Typography;
+
+type StatusFilter = 'all' | ReservationStatus;
+type TimeFilter = 'today' | 'tomorrow' | 'week';
+
+const statusLabels: Record<ReservationStatus, string> = {
+  PENDING: 'Onay bekliyor',
+  CONFIRMED: 'Onaylandı',
+  CANCELLED: 'İptal edildi',
+  COMPLETED: 'Tamamlandı',
+};
+
+const statusColors: Record<ReservationStatus, string> = {
+  PENDING: 'processing',
+  CONFIRMED: 'success',
+  CANCELLED: 'error',
+  COMPLETED: 'default',
+};
+
+const timelineColors: Record<ReservationStatus, string> = {
+  PENDING: '#2563eb',
+  CONFIRMED: '#16a34a',
+  CANCELLED: '#dc2626',
+  COMPLETED: '#6b7280',
+};
+
+const Reservations: React.FC = () => {
+  const [reservations, setReservations] = useState<Reservation[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [timeFilter, setTimeFilter] = useState<TimeFilter>('today');
+  const [createModalOpen, setCreateModalOpen] = useState(false);
+  const [createLoading, setCreateLoading] = useState(false);
+  const [form] = Form.useForm<{ date: Dayjs; status: ReservationStatus; notes?: string }>();
+
+  const loadReservations = useCallback(async () => {
+    try {
+      setLoading(true);
+      const response = await reservationService.list({ page: 0, size: 200, sort: 'date,desc' });
+      setReservations(response.items);
+      setError(null);
+    } catch {
+      setError('Rezervasyon verileri alınamadı.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadReservations();
+  }, [loadReservations]);
+
+  const handleCreateReservation = async (values: { date: Dayjs; status: ReservationStatus; notes?: string }) => {
+    try {
+      setCreateLoading(true);
+      await reservationService.create({
+        date: values.date.toISOString(),
+        status: values.status,
+        notes: values.notes,
+      });
+      message.success('Rezervasyon başarıyla oluşturuldu.');
+      setCreateModalOpen(false);
+      form.resetFields();
+      await loadReservations();
+    } catch {
+      message.error('Rezervasyon oluşturulurken bir hata meydana geldi.');
+    } finally {
+      setCreateLoading(false);
+    }
+  };
+
+  const reservationHighlights = useMemo(() => {
+    const total = reservations.length;
+    const upcoming = reservations.filter(reservation => dayjs(reservation.date).isAfter(dayjs())).length;
+    const pending = reservations.filter(reservation => reservation.status === 'PENDING').length;
+    const confirmed = reservations.filter(reservation => reservation.status === 'CONFIRMED').length;
+    const cancelled = reservations.filter(reservation => reservation.status === 'CANCELLED').length;
+
+    return [
+      {
+        title: 'Toplam Rezervasyon',
+        value: total,
+        helper: `${confirmed + pending} aktif işlem`,
+        progress: total ? Math.round(((confirmed + pending) / total) * 100) : 0,
+        accent: '#2563eb',
+      },
+      {
+        title: 'Yaklaşan Rezervasyon',
+        value: upcoming,
+        helper: `${total ? Math.round((upcoming / total) * 100) : 0}% gelecek`,
+        progress: total ? Math.round((upcoming / total) * 100) : 0,
+        accent: '#38bdf8',
+      },
+      {
+        title: 'Onay Bekleyen',
+        value: pending,
+        helper: `${total ? Math.round((pending / total) * 100) : 0}% oran`,
+        progress: total ? Math.round((pending / total) * 100) : 0,
+        accent: '#f97316',
+      },
+      {
+        title: 'İptal Edilen',
+        value: cancelled,
+        helper: `${total ? Math.round((cancelled / total) * 100) : 0}% oran`,
+        progress: total ? Math.round((cancelled / total) * 100) : 0,
+        accent: '#10b981',
+      },
+    ];
+  }, [reservations]);
+
+  const filteredReservations = useMemo(() => {
+    return reservations
+      .filter(reservation => {
+        const matchesStatus = statusFilter === 'all' || reservation.status === statusFilter;
+
+        let matchesTime = true;
+        if (timeFilter === 'today') {
+          matchesTime = dayjs(reservation.date).isSame(dayjs(), 'day');
+        } else if (timeFilter === 'tomorrow') {
+          matchesTime = dayjs(reservation.date).isSame(dayjs().add(1, 'day'), 'day');
+        } else if (timeFilter === 'week') {
+          matchesTime = dayjs(reservation.date).isBetween(dayjs().startOf('week'), dayjs().endOf('week'), 'day', '[]');
+        }
+
+        return matchesStatus && matchesTime;
+      })
+      .sort((a, b) => dayjs(a.date).valueOf() - dayjs(b.date).valueOf());
+  }, [reservations, statusFilter, timeFilter]);
+
+  const statusDistribution = useMemo(() => {
+    const total = reservations.length || 1;
+    const counts: Record<ReservationStatus, number> = {
+      PENDING: 0,
+      CONFIRMED: 0,
+      CANCELLED: 0,
+      COMPLETED: 0,
+    };
+
+    reservations.forEach(reservation => {
+      counts[reservation.status] += 1;
+    });
+
+    return (Object.keys(counts) as ReservationStatus[]).map(status => ({
+      status,
+      count: counts[status],
+      ratio: Math.round((counts[status] / total) * 100),
+    }));
+  }, [reservations]);
+
+  const timelineEntries = useMemo(() => {
+    const todaysReservations = reservations
+      .filter(reservation => dayjs(reservation.date).isSame(dayjs(), 'day'))
+      .sort((a, b) => dayjs(a.date).valueOf() - dayjs(b.date).valueOf());
+
+    if (!todaysReservations.length) {
+      return [
+        {
+          color: '#94a3b8',
+          children: <Text>Bugün için planlanmış rezervasyon bulunmuyor.</Text>,
+        },
+      ];
+    }
+
+    return todaysReservations.map(reservation => {
+      const customerName = [reservation.customer?.firstName, reservation.customer?.lastName].filter(Boolean).join(' ') || 'Müşteri';
+      const serviceName = reservation.service?.name ?? 'Hizmet bilgisi yok';
+      return {
+        color: timelineColors[reservation.status],
+        dot: <ClockCircleOutlined style={{ fontSize: 14 }} />,
+        children: (
+          <div className="reservations-timeline-item">
+            <Text className="reservations-timeline-time">{dayjs(reservation.date).format('HH:mm')}</Text>
+            <Text className="reservations-timeline-title">{statusLabels[reservation.status]}</Text>
+            <Text className="reservations-timeline-description">{`${customerName} · ${serviceName}`}</Text>
+          </div>
+        ),
+      };
+    });
+  }, [reservations]);
+
+  const statusOptions = useMemo(
+    () =>
+      (Object.keys(statusLabels) as ReservationStatus[]).map(status => ({
+        label: statusLabels[status],
+        value: status,
+      })),
+    [],
+  );
+
+  return (
+    <>
+      <main className="workspace-page reservations-page">
+        <Topbar />
+        <header className="workspace-header">
+          <div>
+            <Text className="workspace-eyebrow">Operasyon Kontrolü</Text>
+            <Title level={2}>Rezervasyon Yönetimi</Title>
+            <Text className="workspace-subtitle">
+              Günlük rezervasyon akışınızı takip edin, yoğunluk noktalarını analiz edin ve ekibinizin odaklanması gereken adımları
+              planlayın.
+            </Text>
+          </div>
+          <Space size={16} className="workspace-actions" wrap>
+            <RangePicker suffixIcon={<CalendarOutlined />} />
+            <Select
+              defaultValue="today"
+              value={timeFilter}
+              onChange={value => setTimeFilter(value as TimeFilter)}
+              options={[
+                { label: 'Bugün', value: 'today' },
+                { label: 'Yarın', value: 'tomorrow' },
+                { label: 'Bu Hafta', value: 'week' },
+              ]}
+            />
+            <Button type="primary" onClick={() => setCreateModalOpen(true)}>
+              Yeni Rezervasyon
+            </Button>
+          </Space>
+        </header>
+
+        {loading ? (
+          <div className="workspace-loader">
+            <Spin size="large" />
+          </div>
+        ) : (
+          <>
+            {error && (
+              <div className="workspace-error">
+                <Text type="danger">{error}</Text>
+              </div>
+            )}
+
+            <section className="workspace-section reservations-overview">
+              <div className="workspace-stat-grid">
+                {reservationHighlights.map(stat => (
+                  <Card key={stat.title} className="workspace-stat-card" bordered={false}>
+                    <Text className="workspace-stat-label">{stat.title}</Text>
+                    <div className="reservations-stat-value">
+                      <Title level={3}>{stat.value}</Title>
+                      <span className="reservations-helper" style={{ color: stat.accent }}>
+                        {stat.helper}
+                      </span>
+                    </div>
+                    <Progress
+                      percent={Math.min(100, stat.progress)}
+                      strokeColor={stat.accent}
+                      trailColor="rgba(148, 163, 184, 0.18)"
+                      strokeLinecap="round"
+                    />
+                  </Card>
+                ))}
+              </div>
+            </section>
+
+            <section className="workspace-section reservations-grid">
+              <Card className="workspace-card reservations-list-card" bordered={false}>
+                <div className="workspace-card-header">
+                  <div>
+                    <Text className="workspace-stat-label">Rezervasyon Akışı</Text>
+                    <Title level={4}>Günlük Takip</Title>
+                  </div>
+                  <Tag icon={<LineChartOutlined />} className="workspace-pill">
+                    {reservations.length} kayıt
+                  </Tag>
+                </div>
+                <div className="reservations-filters">
+                  <Select
+                    value={statusFilter}
+                    onChange={value => setStatusFilter(value as StatusFilter)}
+                    options={[
+                      { label: 'Tümü', value: 'all' },
+                      { label: 'Onaylı', value: 'CONFIRMED' },
+                      { label: 'Onay Bekliyor', value: 'PENDING' },
+                      { label: 'Tamamlanan', value: 'COMPLETED' },
+                      { label: 'İptal', value: 'CANCELLED' },
+                    ]}
+                  />
+                  <Select
+                    value={timeFilter}
+                    onChange={value => setTimeFilter(value as TimeFilter)}
+                    options={[
+                      { label: 'Bugün', value: 'today' },
+                      { label: 'Yarın', value: 'tomorrow' },
+                      { label: 'Bu Hafta', value: 'week' },
+                    ]}
+                  />
+                </div>
+                <List
+                  className="reservations-list"
+                  dataSource={filteredReservations}
+                  locale={{ emptyText: <Empty description="Seçilen filtrelerle eşleşen kayıt bulunmuyor." /> }}
+                  renderItem={item => {
+                    const customerName = [item.customer?.firstName, item.customer?.lastName].filter(Boolean).join(' ') || 'Müşteri';
+                    const serviceName = item.service?.name ?? 'Hizmet bilgisi yok';
+                    return (
+                      <List.Item className="reservations-item" key={item.id}>
+                        <List.Item.Meta
+                          avatar={<Avatar>{customerName.charAt(0)}</Avatar>}
+                          title={customerName}
+                          description={<span className="reservations-service">{serviceName}</span>}
+                        />
+                        <div className="reservations-meta">
+                          <Text className="reservations-time">{dayjs(item.date).format('DD MMM YYYY HH:mm')}</Text>
+                          <Tag color={statusColors[item.status]} className="reservations-status">
+                            {statusLabels[item.status]}
+                          </Tag>
+                        </div>
+                      </List.Item>
+                    );
+                  }}
+                />
+              </Card>
+
+              <Card className="workspace-card reservations-channel-card" bordered={false}>
+                <div className="workspace-card-header">
+                  <div>
+                    <Text className="workspace-stat-label">Durum Dağılımı</Text>
+                    <Title level={4}>Operasyon Özeti</Title>
+                  </div>
+                  <Tag icon={<ThunderboltOutlined />} className="workspace-pill">
+                    Gerçek zamanlı
+                  </Tag>
+                </div>
+                <div className="reservations-channel-list">
+                  {statusDistribution.map(item => (
+                    <div key={item.status} className="reservations-channel-item">
+                      <div className="reservations-channel-header">
+                        <Text className="reservations-channel-name">{statusLabels[item.status]}</Text>
+                        <Text className="reservations-channel-value">%{item.ratio}</Text>
+                      </div>
+                      <Progress percent={item.ratio} strokeColor="#2563eb" trailColor="rgba(148, 163, 184, 0.16)" strokeLinecap="round" />
+                    </div>
+                  ))}
+                </div>
+
+                <div className="reservations-timeline-card">
+                  <Text className="workspace-stat-label">Bugünkü İş Akışı</Text>
+                  <Timeline className="reservations-timeline" items={timelineEntries} />
+                </div>
+              </Card>
+            </section>
+          </>
+        )}
+      </main>
+      <Modal
+        title="Yeni Rezervasyon Oluştur"
+        open={createModalOpen}
+        onCancel={() => setCreateModalOpen(false)}
+        onOk={() => form.submit()}
+        confirmLoading={createLoading}
+        okText="Kaydet"
+        cancelText="İptal"
+      >
+        <Form form={form} layout="vertical" onFinish={handleCreateReservation} initialValues={{ status: 'PENDING' as ReservationStatus }}>
+          <Form.Item name="date" label="Rezervasyon Tarihi" rules={[{ required: true, message: 'Rezervasyon tarihini seçiniz.' }]}>
+            <DatePicker showTime format="DD.MM.YYYY HH:mm" className="reservation-create-date-picker" style={{ width: '100%' }} />
+          </Form.Item>
+          <Form.Item name="status" label="Durum" rules={[{ required: true, message: 'Rezervasyon durumunu belirtiniz.' }]}>
+            <Select options={statusOptions} />
+          </Form.Item>
+          <Form.Item name="notes" label="Notlar">
+            <Input.TextArea rows={3} placeholder="Opsiyonel açıklama ekleyebilirsiniz." />
+          </Form.Item>
+        </Form>
+      </Modal>
+    </>
+  );
+};
+
+export default Reservations;

--- a/frontend/src/pages/Reservations/styles.css
+++ b/frontend/src/pages/Reservations/styles.css
@@ -1,0 +1,188 @@
+.reservations-page .workspace-stat-card .ant-card-body {
+  gap: 16px;
+}
+
+.reservations-stat-value {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.reservations-stat-value h3.ant-typography {
+  margin: 0;
+  font-size: clamp(26px, 2.6vw, 32px);
+}
+
+.reservations-helper {
+  font-weight: 600;
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.04);
+  border: 1px solid currentColor;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.45);
+}
+
+.reservations-grid {
+  grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+}
+
+.reservations-list-card .reservations-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.reservations-list-card .reservations-filters .ant-select-selector {
+  border-radius: 12px !important;
+  border: 1px solid rgba(148, 163, 184, 0.2) !important;
+  background: rgba(255, 255, 255, 0.85) !important;
+  box-shadow: 0 16px 40px -32px rgba(15, 23, 42, 0.28);
+  padding: 0 12px !important;
+}
+
+.reservations-list {
+  margin-top: 12px;
+}
+
+.reservations-item {
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  padding: 16px 0 !important;
+}
+
+.reservations-item:last-child {
+  border-bottom: none;
+  padding-bottom: 0 !important;
+}
+
+.reservations-item .ant-avatar {
+  background: linear-gradient(135deg, var(--color-primary), var(--color-accent));
+  font-weight: 600;
+}
+
+.reservations-service {
+  color: rgba(71, 85, 105, 0.78);
+}
+
+.reservations-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+}
+
+.reservations-time {
+  font-weight: 600;
+  color: rgba(30, 41, 59, 0.72);
+}
+
+.reservations-status.ant-tag {
+  border-radius: 999px;
+  padding: 2px 12px;
+  font-weight: 600;
+}
+
+.reservations-channel-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.reservations-channel-item {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.reservations-channel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.reservations-channel-name {
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.85);
+}
+
+.reservations-channel-tag.ant-tag {
+  border-radius: 999px;
+  padding: 2px 10px;
+  font-weight: 600;
+  border: none;
+}
+
+.reservations-timeline-header {
+  margin-top: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.reservations-timeline .ant-timeline-item-tail {
+  background: rgba(148, 163, 184, 0.3);
+}
+
+.reservations-timeline .ant-timeline-item-head {
+  background: rgba(37, 99, 235, 0.12);
+  border: none;
+  box-shadow: 0 10px 30px -20px rgba(37, 99, 235, 0.65);
+}
+
+.reservations-timeline-dot {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.95), rgba(56, 189, 248, 0.9));
+  color: #ffffff;
+  box-shadow: 0 20px 45px -30px rgba(30, 58, 138, 0.75);
+}
+
+.reservations-timeline-item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px 0;
+}
+
+.reservations-timeline-time {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(37, 99, 235, 0.75);
+}
+
+.reservations-timeline-title {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.reservations-timeline-description {
+  color: rgba(71, 85, 105, 0.75);
+}
+
+.reservations-timeline h5.ant-typography {
+  margin: 0;
+}
+
+@media (max-width: 960px) {
+  .reservations-meta {
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 640px) {
+  .reservations-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .reservations-stat-value {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/frontend/src/pages/Welcome/index.tsx
+++ b/frontend/src/pages/Welcome/index.tsx
@@ -1,0 +1,173 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Button, Card, Col, DatePicker, Form, Input, Row, Space, Typography, message } from 'antd';
+import dayjs from 'dayjs';
+import type { Dayjs } from 'dayjs';
+import { publicReservationService, type PublicReservationPayload } from '../../services/api';
+import './styles.css';
+
+const { Title, Paragraph, Text } = Typography;
+
+interface ReservationFormValues {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+  reservationDate: Dayjs;
+  notes?: string;
+}
+
+const featureHighlights = [
+  {
+    title: 'Dakik Planlama',
+    description: 'Hizmetleriniz için uygun zaman dilimini seçin ve rezervasyonunuzu saniyeler içinde tamamlayın.',
+  },
+  {
+    title: 'Ekip Takibi',
+    description: 'Yönetici paneli ile tüm rezervasyonları ve müşteri taleplerini tek bir yerden kontrol edin.',
+  },
+  {
+    title: 'Otomatik Bilgilendirme',
+    description: 'Onaylanan işlemler için e-posta ve SMS bilgilendirmeleri ile müşterilerinizi sürekli haberdar edin.',
+  },
+];
+
+const Welcome: React.FC = () => {
+  const [form] = Form.useForm<ReservationFormValues>();
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (values: ReservationFormValues) => {
+    const payload: PublicReservationPayload = {
+      firstName: values.firstName,
+      lastName: values.lastName,
+      email: values.email,
+      phone: values.phone,
+      reservationDate: values.reservationDate.toISOString(),
+      notes: values.notes,
+    };
+
+    try {
+      setSubmitting(true);
+      await publicReservationService.create(payload);
+      message.success('Talebiniz başarıyla alındı. Ekibimiz en kısa sürede sizinle iletişime geçecek.');
+      form.resetFields();
+    } catch (error) {
+      console.error('Public reservation request failed', error);
+      message.error('Rezervasyon isteğiniz gönderilemedi. Lütfen tekrar deneyin.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="welcome-page">
+      <div className="welcome-hero">
+        <div className="welcome-hero-content">
+          <Text className="welcome-badge">Rezervasyon Yönetim Sistemi</Text>
+          <Title>Modern bir rezervasyon deneyimi sunun</Title>
+          <Paragraph>
+            Misafirlerinizin hızlıca rezervasyon oluşturabildiği, yöneticilerin ise gelişmiş bir panel üzerinden tüm süreci takip edebildiği
+            esnek bir çözüm tasarladık. Hemen rezervasyon formunu doldurarak talebinizi iletebilirsiniz.
+          </Paragraph>
+          <Space size={16} wrap>
+            <Button
+              type="primary"
+              size="large"
+              onClick={() => document.getElementById('reservation-form')?.scrollIntoView({ behavior: 'smooth' })}
+            >
+              Rezervasyon Oluştur
+            </Button>
+            <Link to="/login" className="welcome-login-link">
+              Yönetici girişi yap
+            </Link>
+          </Space>
+        </div>
+      </div>
+
+      <section className="welcome-features">
+        <Row gutter={[24, 24]}>
+          {featureHighlights.map(feature => (
+            <Col xs={24} md={8} key={feature.title}>
+              <Card bordered={false} className="welcome-feature-card">
+                <Title level={4}>{feature.title}</Title>
+                <Paragraph>{feature.description}</Paragraph>
+              </Card>
+            </Col>
+          ))}
+        </Row>
+      </section>
+
+      <section className="welcome-form-wrapper" id="reservation-form">
+        <Row gutter={[32, 32]} align="middle">
+          <Col xs={24} md={12}>
+            <div className="welcome-form-copy">
+              <Title level={3}>Rezervasyon formunu doldurun</Title>
+              <Paragraph>
+                Talep ettiğiniz tarih ve iletişim bilgileriniz bize ulaştığında, rezervasyonunuzu onaylamak için sizinle iletişime
+                geçeceğiz. Tüm bilgileriniz güvenli olarak saklanır ve yalnızca rezervasyon amacıyla kullanılır.
+              </Paragraph>
+              <ul className="welcome-benefits">
+                <li>Güvenli veri aktarımı ve kayıt</li>
+                <li>Hızlı dönüş yapan operasyon ekibi</li>
+                <li>İhtiyaçlarınıza göre şekillenen hizmetler</li>
+              </ul>
+            </div>
+          </Col>
+          <Col xs={24} md={12}>
+            <Card bordered={false} className="welcome-form-card">
+              <Title level={4}>Misafir Rezervasyonu</Title>
+              <Form layout="vertical" form={form} onFinish={handleSubmit} requiredMark={false}>
+                <Row gutter={16}>
+                  <Col span={12}>
+                    <Form.Item name="firstName" label="Ad" rules={[{ required: true, message: 'Lütfen adınızı girin.' }]}>
+                      <Input placeholder="Örneğin Ayşe" autoComplete="given-name" />
+                    </Form.Item>
+                  </Col>
+                  <Col span={12}>
+                    <Form.Item name="lastName" label="Soyad" rules={[{ required: true, message: 'Lütfen soyadınızı girin.' }]}>
+                      <Input placeholder="Örneğin Yılmaz" autoComplete="family-name" />
+                    </Form.Item>
+                  </Col>
+                </Row>
+                <Form.Item
+                  name="email"
+                  label="E-posta"
+                  rules={[
+                    { required: true, message: 'Lütfen e-posta adresinizi girin.' },
+                    { type: 'email', message: 'Geçerli bir e-posta adresi giriniz.' },
+                  ]}
+                >
+                  <Input placeholder="ornek@mail.com" autoComplete="email" />
+                </Form.Item>
+                <Form.Item name="phone" label="Telefon" rules={[{ required: true, message: 'Lütfen telefon numaranızı girin.' }]}>
+                  <Input placeholder="05xx xxx xx xx" autoComplete="tel" />
+                </Form.Item>
+                <Form.Item
+                  name="reservationDate"
+                  label="Tercih Edilen Tarih"
+                  rules={[{ required: true, message: 'Lütfen bir tarih seçin.' }]}
+                >
+                  <DatePicker
+                    showTime
+                    className="welcome-date-picker"
+                    style={{ width: '100%' }}
+                    format="DD.MM.YYYY HH:mm"
+                    disabledDate={current => current && current < dayjs().startOf('day')}
+                  />
+                </Form.Item>
+                <Form.Item name="notes" label="Notunuz (opsiyonel)">
+                  <Input.TextArea rows={4} placeholder="İhtiyaçlarınızı veya tercihlerinizi buraya yazabilirsiniz." />
+                </Form.Item>
+                <Button type="primary" htmlType="submit" size="large" loading={submitting} block>
+                  Rezervasyon Talebi Gönder
+                </Button>
+              </Form>
+            </Card>
+          </Col>
+        </Row>
+      </section>
+    </div>
+  );
+};
+
+export default Welcome;

--- a/frontend/src/pages/Welcome/styles.css
+++ b/frontend/src/pages/Welcome/styles.css
@@ -1,0 +1,117 @@
+.welcome-page {
+  min-height: 100vh;
+  background: linear-gradient(180deg, rgba(37, 99, 235, 0.08) 0%, rgba(15, 23, 42, 0.04) 100%);
+  color: #0f172a;
+}
+
+.welcome-hero {
+  padding: 96px 24px 64px;
+  background:
+    radial-gradient(circle at top left, rgba(14, 165, 233, 0.28), transparent 55%),
+    radial-gradient(circle at top right, rgba(96, 165, 250, 0.34), transparent 65%), rgba(15, 23, 42, 0.04);
+  display: flex;
+  justify-content: center;
+}
+
+.welcome-hero-content {
+  max-width: 960px;
+  text-align: center;
+}
+
+.welcome-badge {
+  display: inline-block;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+  font-weight: 600;
+  margin-bottom: 16px;
+}
+
+.welcome-hero-content .ant-typography {
+  color: inherit;
+}
+
+.welcome-hero-content h1.ant-typography {
+  font-size: clamp(2.6rem, 4vw, 3.4rem);
+  font-weight: 700;
+  margin-bottom: 16px;
+}
+
+.welcome-hero-content .ant-typography + .ant-typography {
+  font-size: 1.1rem;
+  color: #334155;
+}
+
+.welcome-login-link {
+  display: inline-flex;
+  align-items: center;
+  font-weight: 600;
+  color: #1d4ed8;
+}
+
+.welcome-login-link:hover {
+  color: #1e3a8a;
+}
+
+.welcome-features {
+  padding: 48px 24px;
+  max-width: 1080px;
+  margin: 0 auto;
+}
+
+.welcome-feature-card {
+  background: rgba(255, 255, 255, 0.88);
+  border-radius: 20px;
+  box-shadow: 0 24px 48px -24px rgba(15, 23, 42, 0.3);
+  backdrop-filter: blur(12px);
+  min-height: 200px;
+}
+
+.welcome-feature-card .ant-typography {
+  color: #0f172a;
+}
+
+.welcome-form-wrapper {
+  padding: 32px 24px 96px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.welcome-form-copy {
+  padding-right: 24px;
+}
+
+.welcome-form-copy .ant-typography {
+  color: #0f172a;
+}
+
+.welcome-form-copy ul {
+  margin: 24px 0 0;
+  padding-left: 20px;
+  color: #1e293b;
+  font-weight: 500;
+}
+
+.welcome-form-card {
+  border-radius: 24px;
+  box-shadow: 0 28px 56px -32px rgba(15, 23, 42, 0.45);
+  background: rgba(255, 255, 255, 0.96);
+  backdrop-filter: blur(16px);
+  padding: 32px;
+}
+
+.welcome-date-picker .ant-picker-input > input::placeholder {
+  color: rgba(51, 65, 85, 0.6);
+}
+
+@media (max-width: 768px) {
+  .welcome-hero {
+    padding-top: 72px;
+  }
+
+  .welcome-form-copy {
+    padding-right: 0;
+    margin-bottom: 24px;
+  }
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,9 +1,7 @@
-import axios from 'axios';
+import axios, { type AxiosResponse } from 'axios';
 
-// API için temel URL
 const API_URL = 'http://localhost:8080/api';
 
-// Axios instance oluşturma
 const api = axios.create({
   baseURL: API_URL,
   headers: {
@@ -11,46 +9,201 @@ const api = axios.create({
   },
 });
 
-// Request interceptor - her istekte token kontrolü
 api.interceptors.request.use(
-  (config) => {
+  config => {
     const token = localStorage.getItem('token');
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }
     return config;
   },
-  (error) => {
-    return Promise.reject(error);
-  }
+  error => Promise.reject(error),
 );
 
-// Response interceptor - 401 hatası durumunda logout
 api.interceptors.response.use(
-  (response) => {
-    return response;
-  },
-  (error) => {
+  response => response,
+  error => {
     if (error.response && error.response.status === 401) {
       localStorage.removeItem('token');
       window.location.href = '/login';
     }
     return Promise.reject(error);
-  }
+  },
 );
 
-// Auth servisleri
+export type ReservationStatus = 'PENDING' | 'CONFIRMED' | 'CANCELLED' | 'COMPLETED';
+export type PaymentStatus = 'PENDING' | 'PAID' | 'FAILED' | 'REFUNDED';
+export type PaymentMethod = 'CREDIT_CARD' | 'DEBIT_CARD' | 'CASH' | 'APPLE_PAY' | 'GOOGLE_PAY' | 'OTHER';
+
+export interface Business {
+  id: number;
+  name: string;
+  type: string;
+  address?: string;
+  phone?: string;
+  email?: string;
+  description?: string;
+}
+
+export interface OfferedService {
+  id: number;
+  name: string;
+  description?: string;
+  duration?: number;
+  price?: number;
+  business?: Business;
+}
+
+export interface Customer {
+  id: number;
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+  notes?: string;
+  business?: Business;
+}
+
+export interface Reservation {
+  id: number;
+  date: string;
+  status: ReservationStatus;
+  notes?: string;
+  service?: OfferedService;
+  customer?: Customer;
+  business?: Business;
+}
+
+export interface ReservationCreateInput {
+  date: string;
+  status: ReservationStatus;
+  notes?: string;
+  serviceId?: number;
+  customerId?: number;
+  businessId?: number;
+}
+
+export interface PublicReservationPayload {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+  reservationDate: string;
+  notes?: string;
+  offeredServiceId?: number;
+  businessId?: number;
+}
+
+export interface Payment {
+  id: number;
+  amount: number;
+  method: PaymentMethod;
+  status: PaymentStatus;
+  transactionId?: string;
+  reservation?: Reservation;
+  customer?: Customer;
+  business?: Business;
+}
+
+export interface AdminUser {
+  id?: number;
+  login: string;
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  imageUrl?: string;
+  activated?: boolean;
+  langKey?: string;
+  authorities?: string[];
+}
+
+interface ListParams {
+  page?: number;
+  size?: number;
+  sort?: string;
+}
+
+interface PaginatedResponse<T> {
+  items: T[];
+  total: number;
+}
+
+const parseTotal = <T>(response: AxiosResponse<T[]>): number => {
+  const raw = response.headers?.['x-total-count'];
+  const total = raw ? Number(raw) : response.data.length;
+  return Number.isNaN(total) ? response.data.length : total;
+};
+
 export const authService = {
-  login: (username: string, password: string) => {
-    return api.post('/authenticate', {username, password});
+  async login(username: string, password: string, rememberMe = false) {
+    const response = await api.post<{ id_token: string }>('/authenticate', { username, password, rememberMe });
+    return response.data.id_token;
   },
-  logout: () => {
+  logout() {
     localStorage.removeItem('token');
     window.location.href = '/login';
   },
-  isAuthenticated: () => {
+  isAuthenticated() {
     return localStorage.getItem('token') !== null;
-  }
+  },
+};
+
+export const reservationService = {
+  async list(params?: ListParams): Promise<PaginatedResponse<Reservation>> {
+    const response = await api.get<Reservation[]>('/reservations', { params });
+    return { items: response.data, total: parseTotal(response) };
+  },
+  async create(payload: ReservationCreateInput): Promise<Reservation> {
+    const response = await api.post<Reservation>('/reservations', {
+      date: payload.date,
+      status: payload.status,
+      notes: payload.notes,
+      service: payload.serviceId ? { id: payload.serviceId } : undefined,
+      customer: payload.customerId ? { id: payload.customerId } : undefined,
+      business: payload.businessId ? { id: payload.businessId } : undefined,
+    });
+    return response.data;
+  },
+};
+
+export const customerService = {
+  async list(params?: ListParams): Promise<PaginatedResponse<Customer>> {
+    const response = await api.get<Customer[]>('/customers', { params });
+    return { items: response.data, total: parseTotal(response) };
+  },
+};
+
+export const paymentService = {
+  async list(params?: ListParams): Promise<PaginatedResponse<Payment>> {
+    const response = await api.get<Payment[]>('/payments', { params });
+    return { items: response.data, total: parseTotal(response) };
+  },
+};
+
+export const businessService = {
+  async list(params?: ListParams): Promise<PaginatedResponse<Business>> {
+    const response = await api.get<Business[]>('/businesses', { params });
+    return { items: response.data, total: parseTotal(response) };
+  },
+};
+
+export const accountService = {
+  getProfile() {
+    return api.get<AdminUser>('/account');
+  },
+  updateProfile(payload: AdminUser) {
+    return api.post('/account', payload);
+  },
+  changePassword(currentPassword: string, newPassword: string) {
+    return api.post('/account/change-password', { currentPassword, newPassword });
+  },
+};
+
+export const publicReservationService = {
+  async create(payload: PublicReservationPayload): Promise<Reservation> {
+    const response = await api.post<Reservation>('/public/reservations', payload);
+    return response.data;
+  },
 };
 
 export default api;

--- a/frontend/src/styles/workspace.css
+++ b/frontend/src/styles/workspace.css
@@ -1,0 +1,162 @@
+.workspace-page {
+  min-height: 100vh;
+  padding: clamp(24px, 4vw, 48px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(24px, 5vw, 40px);
+  background:
+    radial-gradient(circle at 18% 22%, rgba(59, 130, 246, 0.14), transparent 52%),
+    radial-gradient(circle at 82% 18%, rgba(56, 189, 248, 0.12), transparent 48%),
+    linear-gradient(165deg, rgba(255, 255, 255, 0.95), rgba(236, 244, 255, 0.82));
+}
+
+.workspace-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: clamp(16px, 3vw, 48px);
+}
+
+.workspace-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 12px;
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.55);
+  display: inline-block;
+  margin-bottom: 12px;
+}
+
+.workspace-subtitle {
+  max-width: 620px;
+  color: rgba(30, 41, 59, 0.68);
+}
+
+.workspace-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 16px;
+}
+
+.workspace-actions .ant-select-selector,
+.workspace-actions .ant-picker {
+  border-radius: 12px !important;
+  border: 1px solid rgba(148, 163, 184, 0.2) !important;
+  background: rgba(255, 255, 255, 0.85) !important;
+  box-shadow: 0 18px 40px -32px rgba(15, 23, 42, 0.35);
+}
+
+.workspace-actions .ant-select-selector {
+  padding: 0 12px !important;
+}
+
+.workspace-actions .ant-picker {
+  padding: 4px 12px;
+}
+
+.workspace-actions .ant-select-arrow {
+  color: var(--color-primary);
+}
+
+.workspace-section {
+  display: grid;
+  gap: clamp(20px, 4vw, 32px);
+}
+
+.workspace-loader {
+  min-height: 320px;
+  display: grid;
+  place-items: center;
+  background: rgba(255, 255, 255, 0.35);
+  border-radius: 24px;
+}
+
+.workspace-error {
+  padding: 16px 24px;
+  border-radius: 16px;
+  background: rgba(248, 113, 113, 0.12);
+  border: 1px solid rgba(248, 113, 113, 0.25);
+}
+
+.workspace-card {
+  border-radius: 22px;
+  background: linear-gradient(140deg, rgba(255, 255, 255, 0.94), rgba(241, 247, 255, 0.88));
+  box-shadow: 0 35px 60px -45px rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(16px);
+  overflow: hidden;
+}
+
+.workspace-card .ant-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: clamp(24px, 4vw, 32px);
+}
+
+.workspace-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: clamp(16px, 3vw, 28px);
+}
+
+.workspace-stat-card {
+  border-radius: 18px;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.95), rgba(236, 245, 255, 0.85));
+  box-shadow: 0 30px 60px -48px rgba(15, 23, 42, 0.55);
+}
+
+.workspace-stat-card .ant-card-body {
+  padding: 24px 26px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.workspace-stat-label {
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(71, 85, 105, 0.75);
+}
+
+.workspace-pill {
+  border-radius: 999px;
+  border: none;
+  padding: 4px 14px;
+  font-weight: 600;
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--color-primary);
+}
+
+.workspace-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+@media (max-width: 960px) {
+  .workspace-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .workspace-actions {
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 640px) {
+  .workspace-page {
+    padding: 24px;
+  }
+
+  .workspace-actions .ant-picker,
+  .workspace-actions .ant-select,
+  .workspace-actions .ant-select-selector {
+    width: 100%;
+  }
+}

--- a/src/main/java/com/mycompany/reservation/config/SecurityConfiguration.java
+++ b/src/main/java/com/mycompany/reservation/config/SecurityConfiguration.java
@@ -69,6 +69,7 @@ public class SecurityConfiguration {
                     .requestMatchers(mvc.pattern("/api/activate")).permitAll()
                     .requestMatchers(mvc.pattern("/api/account/reset-password/init")).permitAll()
                     .requestMatchers(mvc.pattern("/api/account/reset-password/finish")).permitAll()
+                    .requestMatchers(mvc.pattern(HttpMethod.POST, "/api/public/reservations")).permitAll()
                     .requestMatchers(mvc.pattern("/api/admin/**")).hasAuthority(AuthoritiesConstants.ADMIN)
                     .requestMatchers(mvc.pattern("/api/**")).authenticated()
                     .requestMatchers(mvc.pattern("/v3/api-docs/**")).hasAuthority(AuthoritiesConstants.ADMIN)

--- a/src/main/java/com/mycompany/reservation/repository/CustomerRepository.java
+++ b/src/main/java/com/mycompany/reservation/repository/CustomerRepository.java
@@ -10,4 +10,5 @@ import org.springframework.stereotype.Repository;
 @SuppressWarnings("unused")
 @Repository
 public interface CustomerRepository extends JpaRepository<Customer, Long> {
+    java.util.Optional<Customer> findOneByEmailIgnoreCase(String email);
 }

--- a/src/main/java/com/mycompany/reservation/service/GuestReservationService.java
+++ b/src/main/java/com/mycompany/reservation/service/GuestReservationService.java
@@ -1,0 +1,102 @@
+package com.mycompany.reservation.service;
+
+import com.mycompany.reservation.domain.Business;
+import com.mycompany.reservation.domain.Customer;
+import com.mycompany.reservation.domain.OfferedService;
+import com.mycompany.reservation.domain.Reservation;
+import com.mycompany.reservation.domain.enumeration.ReservationStatus;
+import com.mycompany.reservation.repository.BusinessRepository;
+import com.mycompany.reservation.repository.CustomerRepository;
+import com.mycompany.reservation.repository.OfferedServiceRepository;
+import com.mycompany.reservation.repository.ReservationRepository;
+import com.mycompany.reservation.service.dto.GuestReservationRequest;
+import com.mycompany.reservation.service.dto.ReservationDTO;
+import com.mycompany.reservation.service.mapper.ReservationMapper;
+import com.mycompany.reservation.web.rest.errors.BadRequestAlertException;
+import java.util.Locale;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Handles reservation submissions that originate from public (non authenticated) channels.
+ */
+@Service
+@Transactional
+public class GuestReservationService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GuestReservationService.class);
+    private static final String ENTITY_NAME = "reservation";
+
+    private final ReservationRepository reservationRepository;
+    private final ReservationMapper reservationMapper;
+    private final CustomerRepository customerRepository;
+    private final OfferedServiceRepository offeredServiceRepository;
+    private final BusinessRepository businessRepository;
+
+    public GuestReservationService(
+        ReservationRepository reservationRepository,
+        ReservationMapper reservationMapper,
+        CustomerRepository customerRepository,
+        OfferedServiceRepository offeredServiceRepository,
+        BusinessRepository businessRepository
+    ) {
+        this.reservationRepository = reservationRepository;
+        this.reservationMapper = reservationMapper;
+        this.customerRepository = customerRepository;
+        this.offeredServiceRepository = offeredServiceRepository;
+        this.businessRepository = businessRepository;
+    }
+
+    public ReservationDTO createReservation(GuestReservationRequest request) {
+        LOG.debug("Public reservation submission received: {}", request.getEmail());
+
+        Customer customer = findOrCreateCustomer(request);
+        OfferedService offeredService = resolveOfferedService(request);
+        Business business = resolveBusiness(request);
+
+        Reservation reservation = new Reservation()
+            .date(request.getReservationDate())
+            .status(ReservationStatus.PENDING)
+            .notes(request.getNotes());
+
+        reservation.setCustomer(customer);
+        reservation.setService(offeredService);
+        reservation.setBusiness(business);
+
+        Reservation persisted = reservationRepository.save(reservation);
+        LOG.info("Reservation {} stored for guest {}", persisted.getId(), customer.getEmail());
+        return reservationMapper.toDto(persisted);
+    }
+
+    private Customer findOrCreateCustomer(GuestReservationRequest request) {
+        Optional<Customer> existing = customerRepository.findOneByEmailIgnoreCase(request.getEmail());
+        Customer customer = existing.orElseGet(Customer::new);
+        customer.setEmail(request.getEmail().toLowerCase(Locale.ROOT));
+        customer.setFirstName(request.getFirstName());
+        customer.setLastName(request.getLastName());
+        customer.setPhone(request.getPhone());
+        customer.setNotes(request.getNotes());
+        return customerRepository.save(customer);
+    }
+
+    private OfferedService resolveOfferedService(GuestReservationRequest request) {
+        if (request.getOfferedServiceId() == null) {
+            return null;
+        }
+        return offeredServiceRepository
+            .findById(request.getOfferedServiceId())
+            .orElseThrow(() -> new BadRequestAlertException("Geçersiz hizmet seçimi", ENTITY_NAME, "serviceNotFound"));
+    }
+
+    private Business resolveBusiness(GuestReservationRequest request) {
+        if (request.getBusinessId() == null) {
+            return null;
+        }
+        return businessRepository
+            .findById(request.getBusinessId())
+            .orElseThrow(() -> new BadRequestAlertException("Geçersiz işletme seçimi", ENTITY_NAME, "businessNotFound"));
+    }
+}

--- a/src/main/java/com/mycompany/reservation/service/dto/GuestReservationRequest.java
+++ b/src/main/java/com/mycompany/reservation/service/dto/GuestReservationRequest.java
@@ -1,0 +1,105 @@
+package com.mycompany.reservation.service.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.io.Serializable;
+import java.time.ZonedDateTime;
+
+/**
+ * Payload for unauthenticated reservation submissions.
+ */
+public class GuestReservationRequest implements Serializable {
+
+    @NotBlank
+    @Size(max = 80)
+    private String firstName;
+
+    @NotBlank
+    @Size(max = 80)
+    private String lastName;
+
+    @NotBlank
+    @Email
+    @Size(max = 191)
+    private String email;
+
+    @NotBlank
+    @Size(max = 40)
+    private String phone;
+
+    @NotNull
+    private ZonedDateTime reservationDate;
+
+    @Size(max = 2000)
+    private String notes;
+
+    private Long offeredServiceId;
+
+    private Long businessId;
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public ZonedDateTime getReservationDate() {
+        return reservationDate;
+    }
+
+    public void setReservationDate(ZonedDateTime reservationDate) {
+        this.reservationDate = reservationDate;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
+    public Long getOfferedServiceId() {
+        return offeredServiceId;
+    }
+
+    public void setOfferedServiceId(Long offeredServiceId) {
+        this.offeredServiceId = offeredServiceId;
+    }
+
+    public Long getBusinessId() {
+        return businessId;
+    }
+
+    public void setBusinessId(Long businessId) {
+        this.businessId = businessId;
+    }
+}

--- a/src/main/java/com/mycompany/reservation/web/rest/PublicReservationResource.java
+++ b/src/main/java/com/mycompany/reservation/web/rest/PublicReservationResource.java
@@ -1,0 +1,46 @@
+package com.mycompany.reservation.web.rest;
+
+import com.mycompany.reservation.service.GuestReservationService;
+import com.mycompany.reservation.service.dto.GuestReservationRequest;
+import com.mycompany.reservation.service.dto.ReservationDTO;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import tech.jhipster.web.util.HeaderUtil;
+
+/**
+ * Public entry points for reservation creation. These endpoints are intentionally unauthenticated so guests can reserve slots.
+ */
+@RestController
+@RequestMapping("/api/public")
+public class PublicReservationResource {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PublicReservationResource.class);
+    private static final String ENTITY_NAME = "reservation";
+
+    @Value("${jhipster.clientApp.name}")
+    private String applicationName;
+
+    private final GuestReservationService guestReservationService;
+
+    public PublicReservationResource(GuestReservationService guestReservationService) {
+        this.guestReservationService = guestReservationService;
+    }
+
+    @PostMapping("/reservations")
+    public ResponseEntity<ReservationDTO> createReservation(@Valid @RequestBody GuestReservationRequest request) throws URISyntaxException {
+        LOG.debug("REST request to create public reservation");
+        ReservationDTO reservation = guestReservationService.createReservation(request);
+        return ResponseEntity.created(new URI("/api/reservations/" + reservation.getId()))
+            .headers(HeaderUtil.createEntityCreationAlert(applicationName, true, ENTITY_NAME, reservation.getId().toString()))
+            .body(reservation);
+    }
+}


### PR DESCRIPTION
## Summary
- add a welcome landing page with a guest reservation form that submits to the backend
- let authenticated operators create reservations directly from the reservations workspace and extend the API client for create operations
- expose a public reservation endpoint that persists guest submissions, reusing or creating customer records as needed while keeping the route open in security

## Testing
- npm run lint
- ./mvnw -q -DskipTests compile *(fails: Maven download is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d78ae609088328a8503b336bc91334