### PR TITLE
Add admin reservation approval modal and backend support

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,7 +11,7 @@ import { authService } from './services/api';
 import './App.css';
 
 interface RequireAuthProps {
-  children: JSX.Element;
+  children: React.ReactNode;
 }
 
 const RequireAuth: React.FC<RequireAuthProps> = ({ children }) => {

--- a/frontend/src/components/Topbar/index.tsx
+++ b/frontend/src/components/Topbar/index.tsx
@@ -106,19 +106,21 @@ const Topbar: React.FC = () => {
 
   const notificationCount = notifications.length;
 
-  const brandName = business?.name ?? 'Rezervasyon Yönetimi';
+  const defaultBrandName = 'Caplio.ai';
+  const brandName = business?.name?.trim() || defaultBrandName;
   const brandInitials = useMemo(() => {
-    return brandName
+    const normalized = brandName.replace(/[.]/g, ' ');
+    return normalized
       .split(' ')
       .filter(Boolean)
       .slice(0, 2)
       .map(part => part.charAt(0).toUpperCase())
       .join('')
-      .padEnd(2, 'R')
+      .padEnd(2, 'A')
       .slice(0, 2);
   }, [brandName]);
 
-  const brandSubtitle = business?.type ? business.type.toLowerCase().replace(/_/g, ' ') : 'Yönetim Merkezi';
+  const brandSubtitle = business?.type ? business.type.toLowerCase().replace(/_/g, ' ') : 'Operasyon Merkezi';
 
   const handleProfileMenuClick: MenuProps['onClick'] = ({ key }) => {
     if (key === 'profile' || key === 'security') {

--- a/frontend/src/pages/Reservations/styles.css
+++ b/frontend/src/pages/Reservations/styles.css
@@ -84,6 +84,31 @@
   font-weight: 600;
 }
 
+.reservations-meta .ant-btn {
+  margin-top: 4px;
+}
+
+.reservations-approve-details {
+  background: rgba(37, 99, 235, 0.08);
+  border-radius: 12px;
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.reservations-approve-time {
+  font-weight: 600;
+  color: rgba(37, 99, 235, 0.85);
+}
+
+.reservations-approve-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 120px;
+}
+
 .reservations-channel-list {
   display: flex;
   flex-direction: column;

--- a/src/main/java/com/mycompany/reservation/service/dto/ReservationApprovalDTO.java
+++ b/src/main/java/com/mycompany/reservation/service/dto/ReservationApprovalDTO.java
@@ -1,0 +1,19 @@
+package com.mycompany.reservation.service.dto;
+
+import java.io.Serializable;
+
+/**
+ * Payload used when approving an existing reservation.
+ */
+public class ReservationApprovalDTO implements Serializable {
+
+    private String notes;
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+}

--- a/src/main/java/com/mycompany/reservation/web/rest/ReservationResource.java
+++ b/src/main/java/com/mycompany/reservation/web/rest/ReservationResource.java
@@ -4,6 +4,7 @@ import com.mycompany.reservation.domain.enumeration.ReservationStatus;
 import com.mycompany.reservation.repository.ReservationRepository;
 import com.mycompany.reservation.security.AuthoritiesConstants;
 import com.mycompany.reservation.service.ReservationService;
+import com.mycompany.reservation.service.dto.ReservationApprovalDTO;
 import com.mycompany.reservation.service.dto.ReservationDTO;
 import com.mycompany.reservation.service.dto.ReservationFilterCriteria;
 import com.mycompany.reservation.service.dto.ReservationReportDTO;
@@ -231,5 +232,22 @@ public class ReservationResource {
         return ResponseEntity.noContent()
             .headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, id.toString()))
             .build();
+    }
+
+    @PostMapping("/{id}/approve")
+    @PreAuthorize("hasAuthority('" + AuthoritiesConstants.ADMIN + "')")
+    public ResponseEntity<ReservationDTO> approveReservation(
+        @PathVariable("id") Long id,
+        @RequestBody(required = false) ReservationApprovalDTO approvalDTO
+    ) {
+        LOG.debug("REST request to approve Reservation : {}", id);
+        try {
+            ReservationDTO reservationDTO = reservationService.approve(id, approvalDTO != null ? approvalDTO.getNotes() : null);
+            return ResponseEntity.ok()
+                .headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, reservationDTO.getId().toString()))
+                .body(reservationDTO);
+        } catch (IllegalStateException ex) {
+            throw new BadRequestAlertException(ex.getMessage(), ENTITY_NAME, "invalidstatus");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add an approval workflow modal on the reservations page and wire it to the API client
- expose a reservation approval endpoint and DTO on the backend for administrators
- refresh the top bar branding to default to Caplio.ai and flesh out shared API service helpers

## Testing
- npm run build
- ./mvnw -DskipITs test *(fails: Maven distribution download blocked in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c2eb15388328bf0130f740e7e28a