### PR TITLE
Add manual finance entry tracking with invoice uploads

### DIFF
--- a/frontend/src/pages/Finance/styles.css
+++ b/frontend/src/pages/Finance/styles.css
@@ -166,6 +166,94 @@
   color: rgba(15, 23, 42, 0.85);
 }
 
+.finance-entries-section {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.finance-manual-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 24px;
+}
+
+.finance-manual-stats {
+  margin-top: 16px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 18px;
+}
+
+.finance-manual-stat {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  padding: 18px;
+  border-radius: 18px;
+  background: rgba(248, 250, 252, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+.finance-manual-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  font-size: 20px;
+}
+
+.finance-manual-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.finance-entry-form {
+  margin-top: 12px;
+}
+
+.finance-entry-form .ant-form-item {
+  margin-bottom: 16px;
+}
+
+.finance-upload-area .ant-upload.ant-upload-select {
+  display: inline-block;
+}
+
+.finance-uploaded-document {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.finance-upload-hint {
+  font-size: 12px;
+}
+
+.finance-entry-table .ant-table-thead > tr > th {
+  background: rgba(15, 23, 42, 0.02);
+}
+
+.finance-entry-tag {
+  border-radius: 999px;
+  padding: 2px 12px;
+  border: none;
+}
+
+@media (max-width: 960px) {
+  .finance-manual-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .finance-manual-stats {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 960px) {
   .finance-revenue-item,
   .finance-collection-item {

--- a/src/main/java/com/mycompany/reservation/config/CacheConfiguration.java
+++ b/src/main/java/com/mycompany/reservation/config/CacheConfiguration.java
@@ -59,6 +59,8 @@ public class CacheConfiguration {
             createCache(cm, com.mycompany.reservation.domain.Customer.class.getName());
             createCache(cm, com.mycompany.reservation.domain.Reservation.class.getName());
             createCache(cm, com.mycompany.reservation.domain.Payment.class.getName());
+            createCache(cm, com.mycompany.reservation.domain.FinanceDocument.class.getName());
+            createCache(cm, com.mycompany.reservation.domain.FinanceEntry.class.getName());
             createCache(cm, com.mycompany.reservation.service.ReservationService.CUSTOMER_RESERVATION_SUMMARY_CACHE);
             // jhipster-needle-ehcache-add-entry
         };

--- a/src/main/java/com/mycompany/reservation/domain/FinanceDocument.java
+++ b/src/main/java/com/mycompany/reservation/domain/FinanceDocument.java
@@ -1,0 +1,157 @@
+package com.mycompany.reservation.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.*;
+import java.io.Serializable;
+import java.time.Instant;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+
+/**
+ * A FinanceDocument.
+ */
+@Entity
+@Table(name = "finance_document")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+public class FinanceDocument implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "sequenceGenerator")
+    @SequenceGenerator(name = "sequenceGenerator")
+    @Column(name = "id")
+    private Long id;
+
+    @NotNull
+    @Column(name = "file_name", nullable = false)
+    private String fileName;
+
+    @NotNull
+    @Column(name = "content_type", nullable = false)
+    private String contentType;
+
+    @NotNull
+    @Column(name = "file_size", nullable = false)
+    private Long size;
+
+    @NotNull
+    @Lob
+    @JsonIgnore
+    @Column(name = "data", nullable = false)
+    private byte[] data;
+
+    @Column(name = "uploaded_at")
+    private Instant uploadedAt;
+
+    // jhipster-needle-entity-add-field - JHipster will add fields here
+
+    public Long getId() {
+        return this.id;
+    }
+
+    public FinanceDocument id(Long id) {
+        this.setId(id);
+        return this;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getFileName() {
+        return this.fileName;
+    }
+
+    public FinanceDocument fileName(String fileName) {
+        this.setFileName(fileName);
+        return this;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public String getContentType() {
+        return this.contentType;
+    }
+
+    public FinanceDocument contentType(String contentType) {
+        this.setContentType(contentType);
+        return this;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public Long getSize() {
+        return this.size;
+    }
+
+    public FinanceDocument size(Long size) {
+        this.setSize(size);
+        return this;
+    }
+
+    public void setSize(Long size) {
+        this.size = size;
+    }
+
+    public byte[] getData() {
+        return this.data;
+    }
+
+    public FinanceDocument data(byte[] data) {
+        this.setData(data);
+        return this;
+    }
+
+    public void setData(byte[] data) {
+        this.data = data;
+    }
+
+    public Instant getUploadedAt() {
+        return this.uploadedAt;
+    }
+
+    public FinanceDocument uploadedAt(Instant uploadedAt) {
+        this.setUploadedAt(uploadedAt);
+        return this;
+    }
+
+    public void setUploadedAt(Instant uploadedAt) {
+        this.uploadedAt = uploadedAt;
+    }
+
+    // jhipster-needle-entity-add-getters-setters - JHipster will add getters and setters here
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof FinanceDocument)) {
+            return false;
+        }
+        return getId() != null && getId().equals(((FinanceDocument) o).getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+
+    // prettier-ignore
+    @Override
+    public String toString() {
+        return "FinanceDocument{" +
+            "id=" + getId() +
+            ", fileName='" + getFileName() + "'" +
+            ", contentType='" + getContentType() + "'" +
+            ", size=" + getSize() +
+            ", uploadedAt='" + getUploadedAt() + "'" +
+            "}";
+    }
+}

--- a/src/main/java/com/mycompany/reservation/domain/FinanceEntry.java
+++ b/src/main/java/com/mycompany/reservation/domain/FinanceEntry.java
@@ -1,0 +1,160 @@
+package com.mycompany.reservation.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.mycompany.reservation.domain.enumeration.FinanceEntryType;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.*;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+
+/**
+ * A FinanceEntry.
+ */
+@Entity
+@Table(name = "finance_entry")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+@SuppressWarnings("common-java:DuplicatedBlocks")
+public class FinanceEntry implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "sequenceGenerator")
+    @SequenceGenerator(name = "sequenceGenerator")
+    @Column(name = "id")
+    private Long id;
+
+    @NotNull
+    @Column(name = "entry_date", nullable = false)
+    private LocalDate entryDate;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "entry_type", nullable = false)
+    private FinanceEntryType type;
+
+    @NotNull
+    @Column(name = "amount", precision = 21, scale = 2, nullable = false)
+    private BigDecimal amount;
+
+    @Size(max = 500)
+    @Column(name = "description", length = 500)
+    private String description;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JsonIgnoreProperties(value = { "data" }, allowSetters = true)
+    private FinanceDocument document;
+
+    // jhipster-needle-entity-add-field - JHipster will add fields here
+
+    public Long getId() {
+        return this.id;
+    }
+
+    public FinanceEntry id(Long id) {
+        this.setId(id);
+        return this;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public LocalDate getEntryDate() {
+        return this.entryDate;
+    }
+
+    public FinanceEntry entryDate(LocalDate entryDate) {
+        this.setEntryDate(entryDate);
+        return this;
+    }
+
+    public void setEntryDate(LocalDate entryDate) {
+        this.entryDate = entryDate;
+    }
+
+    public FinanceEntryType getType() {
+        return this.type;
+    }
+
+    public FinanceEntry type(FinanceEntryType type) {
+        this.setType(type);
+        return this;
+    }
+
+    public void setType(FinanceEntryType type) {
+        this.type = type;
+    }
+
+    public BigDecimal getAmount() {
+        return this.amount;
+    }
+
+    public FinanceEntry amount(BigDecimal amount) {
+        this.setAmount(amount);
+        return this;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        this.amount = amount;
+    }
+
+    public String getDescription() {
+        return this.description;
+    }
+
+    public FinanceEntry description(String description) {
+        this.setDescription(description);
+        return this;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public FinanceDocument getDocument() {
+        return this.document;
+    }
+
+    public void setDocument(FinanceDocument financeDocument) {
+        this.document = financeDocument;
+    }
+
+    public FinanceEntry document(FinanceDocument financeDocument) {
+        this.setDocument(financeDocument);
+        return this;
+    }
+
+    // jhipster-needle-entity-add-getters-setters - JHipster will add getters and setters here
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof FinanceEntry)) {
+            return false;
+        }
+        return getId() != null && getId().equals(((FinanceEntry) o).getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+
+    // prettier-ignore
+    @Override
+    public String toString() {
+        return "FinanceEntry{" +
+            "id=" + getId() +
+            ", entryDate='" + getEntryDate() + "'" +
+            ", type='" + getType() + "'" +
+            ", amount=" + getAmount() +
+            ", description='" + getDescription() + "'" +
+            "}";
+    }
+}

--- a/src/main/java/com/mycompany/reservation/domain/enumeration/FinanceEntryType.java
+++ b/src/main/java/com/mycompany/reservation/domain/enumeration/FinanceEntryType.java
@@ -1,0 +1,9 @@
+package com.mycompany.reservation.domain.enumeration;
+
+/**
+ * The FinanceEntryType enumeration.
+ */
+public enum FinanceEntryType {
+    INCOME,
+    EXPENSE,
+}

--- a/src/main/java/com/mycompany/reservation/repository/FinanceDocumentRepository.java
+++ b/src/main/java/com/mycompany/reservation/repository/FinanceDocumentRepository.java
@@ -1,0 +1,11 @@
+package com.mycompany.reservation.repository;
+
+import com.mycompany.reservation.domain.FinanceDocument;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Spring Data JPA repository for the FinanceDocument entity.
+ */
+@Repository
+public interface FinanceDocumentRepository extends JpaRepository<FinanceDocument, Long> {}

--- a/src/main/java/com/mycompany/reservation/repository/FinanceEntryRepository.java
+++ b/src/main/java/com/mycompany/reservation/repository/FinanceEntryRepository.java
@@ -1,0 +1,11 @@
+package com.mycompany.reservation.repository;
+
+import com.mycompany.reservation.domain.FinanceEntry;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Spring Data JPA repository for the FinanceEntry entity.
+ */
+@Repository
+public interface FinanceEntryRepository extends JpaRepository<FinanceEntry, Long> {}

--- a/src/main/java/com/mycompany/reservation/service/FinanceDocumentService.java
+++ b/src/main/java/com/mycompany/reservation/service/FinanceDocumentService.java
@@ -1,0 +1,62 @@
+package com.mycompany.reservation.service;
+
+import com.mycompany.reservation.domain.FinanceDocument;
+import com.mycompany.reservation.repository.FinanceDocumentRepository;
+import com.mycompany.reservation.service.dto.FinanceDocumentDTO;
+import com.mycompany.reservation.service.mapper.FinanceDocumentMapper;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * Service Implementation for managing {@link com.mycompany.reservation.domain.FinanceDocument}.
+ */
+@Service
+@Transactional
+public class FinanceDocumentService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FinanceDocumentService.class);
+
+    private final FinanceDocumentRepository financeDocumentRepository;
+    private final FinanceDocumentMapper financeDocumentMapper;
+
+    public FinanceDocumentService(FinanceDocumentRepository financeDocumentRepository, FinanceDocumentMapper financeDocumentMapper) {
+        this.financeDocumentRepository = financeDocumentRepository;
+        this.financeDocumentMapper = financeDocumentMapper;
+    }
+
+    public FinanceDocumentDTO store(MultipartFile file) throws IOException {
+        LOG.debug("Request to store FinanceDocument : {}", file.getOriginalFilename());
+        FinanceDocument financeDocument = new FinanceDocument()
+            .fileName(file.getOriginalFilename() != null ? file.getOriginalFilename() : "invoice")
+            .contentType(file.getContentType() != null ? file.getContentType() : "application/octet-stream")
+            .size(file.getSize())
+            .uploadedAt(Instant.now())
+            .data(file.getBytes());
+
+        financeDocument = financeDocumentRepository.save(financeDocument);
+        return financeDocumentMapper.toDto(financeDocument);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<FinanceDocumentDTO> findOne(Long id) {
+        LOG.debug("Request to get FinanceDocument : {}", id);
+        return financeDocumentRepository.findById(id).map(financeDocumentMapper::toDto);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<FinanceDocument> findEntity(Long id) {
+        LOG.debug("Request to get FinanceDocument entity : {}", id);
+        return financeDocumentRepository.findById(id);
+    }
+
+    public void delete(Long id) {
+        LOG.debug("Request to delete FinanceDocument : {}", id);
+        financeDocumentRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/mycompany/reservation/service/FinanceEntryService.java
+++ b/src/main/java/com/mycompany/reservation/service/FinanceEntryService.java
@@ -1,0 +1,75 @@
+package com.mycompany.reservation.service;
+
+import com.mycompany.reservation.domain.FinanceEntry;
+import com.mycompany.reservation.repository.FinanceEntryRepository;
+import com.mycompany.reservation.service.dto.FinanceEntryDTO;
+import com.mycompany.reservation.service.mapper.FinanceEntryMapper;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Service Implementation for managing {@link com.mycompany.reservation.domain.FinanceEntry}.
+ */
+@Service
+@Transactional
+public class FinanceEntryService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FinanceEntryService.class);
+
+    private final FinanceEntryRepository financeEntryRepository;
+    private final FinanceEntryMapper financeEntryMapper;
+
+    public FinanceEntryService(FinanceEntryRepository financeEntryRepository, FinanceEntryMapper financeEntryMapper) {
+        this.financeEntryRepository = financeEntryRepository;
+        this.financeEntryMapper = financeEntryMapper;
+    }
+
+    public FinanceEntryDTO save(FinanceEntryDTO financeEntryDTO) {
+        LOG.debug("Request to save FinanceEntry : {}", financeEntryDTO);
+        FinanceEntry financeEntry = financeEntryMapper.toEntity(financeEntryDTO);
+        financeEntry = financeEntryRepository.save(financeEntry);
+        return financeEntryMapper.toDto(financeEntry);
+    }
+
+    public FinanceEntryDTO update(FinanceEntryDTO financeEntryDTO) {
+        LOG.debug("Request to update FinanceEntry : {}", financeEntryDTO);
+        FinanceEntry financeEntry = financeEntryMapper.toEntity(financeEntryDTO);
+        financeEntry = financeEntryRepository.save(financeEntry);
+        return financeEntryMapper.toDto(financeEntry);
+    }
+
+    public Optional<FinanceEntryDTO> partialUpdate(FinanceEntryDTO financeEntryDTO) {
+        LOG.debug("Request to partially update FinanceEntry : {}", financeEntryDTO);
+
+        return financeEntryRepository
+            .findById(financeEntryDTO.getId())
+            .map(existingFinanceEntry -> {
+                financeEntryMapper.partialUpdate(existingFinanceEntry, financeEntryDTO);
+
+                return existingFinanceEntry;
+            })
+            .map(financeEntryRepository::save)
+            .map(financeEntryMapper::toDto);
+    }
+
+    @Transactional(readOnly = true)
+    public List<FinanceEntryDTO> findAll() {
+        LOG.debug("Request to get all FinanceEntries");
+        return financeEntryRepository.findAll().stream().map(financeEntryMapper::toDto).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<FinanceEntryDTO> findOne(Long id) {
+        LOG.debug("Request to get FinanceEntry : {}", id);
+        return financeEntryRepository.findById(id).map(financeEntryMapper::toDto);
+    }
+
+    public void delete(Long id) {
+        LOG.debug("Request to delete FinanceEntry : {}", id);
+        financeEntryRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/mycompany/reservation/service/dto/FinanceDocumentDTO.java
+++ b/src/main/java/com/mycompany/reservation/service/dto/FinanceDocumentDTO.java
@@ -1,0 +1,98 @@
+package com.mycompany.reservation.service.dto;
+
+import jakarta.validation.constraints.*;
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * A DTO for the {@link com.mycompany.reservation.domain.FinanceDocument} entity.
+ */
+public class FinanceDocumentDTO implements Serializable {
+
+    private Long id;
+
+    @NotNull
+    private String fileName;
+
+    @NotNull
+    private String contentType;
+
+    @NotNull
+    private Long size;
+
+    private Instant uploadedAt;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public Long getSize() {
+        return size;
+    }
+
+    public void setSize(Long size) {
+        this.size = size;
+    }
+
+    public Instant getUploadedAt() {
+        return uploadedAt;
+    }
+
+    public void setUploadedAt(Instant uploadedAt) {
+        this.uploadedAt = uploadedAt;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof FinanceDocumentDTO)) {
+            return false;
+        }
+
+        FinanceDocumentDTO financeDocumentDTO = (FinanceDocumentDTO) o;
+        if (this.id == null) {
+            return false;
+        }
+        return Objects.equals(this.id, financeDocumentDTO.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.id);
+    }
+
+    // prettier-ignore
+    @Override
+    public String toString() {
+        return "FinanceDocumentDTO{" +
+            "id=" + getId() +
+            ", fileName='" + getFileName() + "'" +
+            ", contentType='" + getContentType() + "'" +
+            ", size=" + getSize() +
+            ", uploadedAt='" + getUploadedAt() + "'" +
+            "}";
+    }
+}

--- a/src/main/java/com/mycompany/reservation/service/dto/FinanceEntryDTO.java
+++ b/src/main/java/com/mycompany/reservation/service/dto/FinanceEntryDTO.java
@@ -1,0 +1,113 @@
+package com.mycompany.reservation.service.dto;
+
+import com.mycompany.reservation.domain.enumeration.FinanceEntryType;
+import jakarta.validation.constraints.*;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Objects;
+
+/**
+ * A DTO for the {@link com.mycompany.reservation.domain.FinanceEntry} entity.
+ */
+@SuppressWarnings("common-java:DuplicatedBlocks")
+public class FinanceEntryDTO implements Serializable {
+
+    private Long id;
+
+    @NotNull
+    private LocalDate entryDate;
+
+    @NotNull
+    private FinanceEntryType type;
+
+    @NotNull
+    private BigDecimal amount;
+
+    @Size(max = 500)
+    private String description;
+
+    private FinanceDocumentDTO document;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public LocalDate getEntryDate() {
+        return entryDate;
+    }
+
+    public void setEntryDate(LocalDate entryDate) {
+        this.entryDate = entryDate;
+    }
+
+    public FinanceEntryType getType() {
+        return type;
+    }
+
+    public void setType(FinanceEntryType type) {
+        this.type = type;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        this.amount = amount;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public FinanceDocumentDTO getDocument() {
+        return document;
+    }
+
+    public void setDocument(FinanceDocumentDTO document) {
+        this.document = document;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof FinanceEntryDTO)) {
+            return false;
+        }
+
+        FinanceEntryDTO financeEntryDTO = (FinanceEntryDTO) o;
+        if (this.id == null) {
+            return false;
+        }
+        return Objects.equals(this.id, financeEntryDTO.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.id);
+    }
+
+    // prettier-ignore
+    @Override
+    public String toString() {
+        return "FinanceEntryDTO{" +
+            "id=" + getId() +
+            ", entryDate='" + getEntryDate() + "'" +
+            ", type='" + getType() + "'" +
+            ", amount=" + getAmount() +
+            ", description='" + getDescription() + "'" +
+            ", document=" + getDocument() +
+            "}";
+    }
+}

--- a/src/main/java/com/mycompany/reservation/service/mapper/FinanceDocumentMapper.java
+++ b/src/main/java/com/mycompany/reservation/service/mapper/FinanceDocumentMapper.java
@@ -1,0 +1,11 @@
+package com.mycompany.reservation.service.mapper;
+
+import com.mycompany.reservation.domain.FinanceDocument;
+import com.mycompany.reservation.service.dto.FinanceDocumentDTO;
+import org.mapstruct.Mapper;
+
+/**
+ * Mapper for the entity {@link com.mycompany.reservation.domain.FinanceDocument} and its DTO {@link FinanceDocumentDTO}.
+ */
+@Mapper(componentModel = "spring")
+public interface FinanceDocumentMapper extends EntityMapper<FinanceDocumentDTO, FinanceDocument> {}

--- a/src/main/java/com/mycompany/reservation/service/mapper/FinanceEntryMapper.java
+++ b/src/main/java/com/mycompany/reservation/service/mapper/FinanceEntryMapper.java
@@ -1,0 +1,25 @@
+package com.mycompany.reservation.service.mapper;
+
+import com.mycompany.reservation.domain.FinanceDocument;
+import com.mycompany.reservation.domain.FinanceEntry;
+import com.mycompany.reservation.service.dto.FinanceDocumentDTO;
+import com.mycompany.reservation.service.dto.FinanceEntryDTO;
+import org.mapstruct.*;
+
+/**
+ * Mapper for the entity {@link com.mycompany.reservation.domain.FinanceEntry} and its DTO {@link FinanceEntryDTO}.
+ */
+@Mapper(componentModel = "spring", uses = { FinanceDocumentMapper.class })
+public interface FinanceEntryMapper extends EntityMapper<FinanceEntryDTO, FinanceEntry> {
+    @Mapping(target = "document", source = "document", qualifiedByName = "financeDocumentSummary")
+    FinanceEntryDTO toDto(FinanceEntry s);
+
+    @Named("financeDocumentSummary")
+    @BeanMapping(ignoreByDefault = true)
+    @Mapping(target = "id", source = "id")
+    @Mapping(target = "fileName", source = "fileName")
+    @Mapping(target = "contentType", source = "contentType")
+    @Mapping(target = "size", source = "size")
+    @Mapping(target = "uploadedAt", source = "uploadedAt")
+    FinanceDocumentDTO toDtoFinanceDocumentSummary(FinanceDocument financeDocument);
+}

--- a/src/main/java/com/mycompany/reservation/web/rest/FinanceDocumentResource.java
+++ b/src/main/java/com/mycompany/reservation/web/rest/FinanceDocumentResource.java
@@ -1,0 +1,87 @@
+package com.mycompany.reservation.web.rest;
+
+import com.mycompany.reservation.domain.FinanceDocument;
+import com.mycompany.reservation.service.FinanceDocumentService;
+import com.mycompany.reservation.service.dto.FinanceDocumentDTO;
+import com.mycompany.reservation.web.rest.errors.BadRequestAlertException;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import tech.jhipster.web.util.HeaderUtil;
+
+/**
+ * REST controller for managing {@link com.mycompany.reservation.domain.FinanceDocument}.
+ */
+@RestController
+@RequestMapping("/api/finance-documents")
+public class FinanceDocumentResource {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FinanceDocumentResource.class);
+
+    private static final String ENTITY_NAME = "financeDocument";
+
+    private final FinanceDocumentService financeDocumentService;
+
+    @Value("${jhipster.clientApp.name}")
+    private String applicationName;
+
+    public FinanceDocumentResource(FinanceDocumentService financeDocumentService) {
+        this.financeDocumentService = financeDocumentService;
+    }
+
+    @PostMapping(value = "", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<FinanceDocumentDTO> uploadDocument(@RequestPart("file") MultipartFile file)
+        throws URISyntaxException, IOException {
+        LOG.debug("REST request to upload FinanceDocument : {}", file.getOriginalFilename());
+        if (file.isEmpty()) {
+            throw new BadRequestAlertException("Dosya yüklenemedi", ENTITY_NAME, "fileempty");
+        }
+
+        FinanceDocumentDTO result = financeDocumentService.store(file);
+        return ResponseEntity.created(new URI("/api/finance-documents/" + result.getId()))
+            .headers(HeaderUtil.createEntityCreationAlert(applicationName, true, ENTITY_NAME, result.getId().toString()))
+            .body(result);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<FinanceDocumentDTO> getFinanceDocument(@PathVariable Long id) {
+        LOG.debug("REST request to get FinanceDocument : {}", id);
+        Optional<FinanceDocumentDTO> financeDocumentDTO = financeDocumentService.findOne(id);
+        return financeDocumentDTO.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/{id}/download")
+    public ResponseEntity<ByteArrayResource> downloadFinanceDocument(@PathVariable Long id) {
+        LOG.debug("REST request to download FinanceDocument : {}", id);
+        Optional<FinanceDocument> financeDocument = financeDocumentService.findEntity(id);
+        if (financeDocument.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        FinanceDocument document = financeDocument.get();
+        ByteArrayResource resource = new ByteArrayResource(document.getData());
+        return ResponseEntity.ok()
+            .contentType(MediaType.parseMediaType(document.getContentType()))
+            .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + document.getFileName())
+            .contentLength(document.getSize())
+            .body(resource);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteFinanceDocument(@PathVariable Long id) {
+        LOG.debug("REST request to delete FinanceDocument : {}", id);
+        financeDocumentService.delete(id);
+        return ResponseEntity.noContent()
+            .headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, id.toString()))
+            .build();
+    }
+}

--- a/src/main/java/com/mycompany/reservation/web/rest/FinanceEntryResource.java
+++ b/src/main/java/com/mycompany/reservation/web/rest/FinanceEntryResource.java
@@ -1,0 +1,126 @@
+package com.mycompany.reservation.web.rest;
+
+import com.mycompany.reservation.repository.FinanceEntryRepository;
+import com.mycompany.reservation.service.FinanceEntryService;
+import com.mycompany.reservation.service.dto.FinanceEntryDTO;
+import com.mycompany.reservation.web.rest.errors.BadRequestAlertException;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import tech.jhipster.web.util.HeaderUtil;
+import tech.jhipster.web.util.ResponseUtil;
+
+/**
+ * REST controller for managing {@link com.mycompany.reservation.domain.FinanceEntry}.
+ */
+@RestController
+@RequestMapping("/api/finance-entries")
+public class FinanceEntryResource {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FinanceEntryResource.class);
+
+    private static final String ENTITY_NAME = "financeEntry";
+
+    @Value("${jhipster.clientApp.name}")
+    private String applicationName;
+
+    private final FinanceEntryService financeEntryService;
+    private final FinanceEntryRepository financeEntryRepository;
+
+    public FinanceEntryResource(FinanceEntryService financeEntryService, FinanceEntryRepository financeEntryRepository) {
+        this.financeEntryService = financeEntryService;
+        this.financeEntryRepository = financeEntryRepository;
+    }
+
+    @PostMapping("")
+    public ResponseEntity<FinanceEntryDTO> createFinanceEntry(@Valid @RequestBody FinanceEntryDTO financeEntryDTO)
+        throws URISyntaxException {
+        LOG.debug("REST request to save FinanceEntry : {}", financeEntryDTO);
+        if (financeEntryDTO.getId() != null) {
+            throw new BadRequestAlertException("A new financeEntry cannot already have an ID", ENTITY_NAME, "idexists");
+        }
+        financeEntryDTO = financeEntryService.save(financeEntryDTO);
+        return ResponseEntity.created(new URI("/api/finance-entries/" + financeEntryDTO.getId()))
+            .headers(HeaderUtil.createEntityCreationAlert(applicationName, true, ENTITY_NAME, financeEntryDTO.getId().toString()))
+            .body(financeEntryDTO);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<FinanceEntryDTO> updateFinanceEntry(
+        @PathVariable(value = "id", required = false) final Long id,
+        @Valid @RequestBody FinanceEntryDTO financeEntryDTO
+    ) throws URISyntaxException {
+        LOG.debug("REST request to update FinanceEntry : {}, {}", id, financeEntryDTO);
+        if (financeEntryDTO.getId() == null) {
+            throw new BadRequestAlertException("Invalid id", ENTITY_NAME, "idnull");
+        }
+        if (!Objects.equals(id, financeEntryDTO.getId())) {
+            throw new BadRequestAlertException("Invalid ID", ENTITY_NAME, "idinvalid");
+        }
+
+        if (!financeEntryRepository.existsById(id)) {
+            throw new BadRequestAlertException("Entity not found", ENTITY_NAME, "idnotfound");
+        }
+
+        financeEntryDTO = financeEntryService.update(financeEntryDTO);
+        return ResponseEntity.ok()
+            .headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, financeEntryDTO.getId().toString()))
+            .body(financeEntryDTO);
+    }
+
+    @PatchMapping(value = "/{id}", consumes = { "application/json", "application/merge-patch+json" })
+    public ResponseEntity<FinanceEntryDTO> partialUpdateFinanceEntry(
+        @PathVariable(value = "id", required = false) final Long id,
+        @NotNull @RequestBody FinanceEntryDTO financeEntryDTO
+    ) throws URISyntaxException {
+        LOG.debug("REST request to partial update FinanceEntry partially : {}, {}", id, financeEntryDTO);
+        if (financeEntryDTO.getId() == null) {
+            throw new BadRequestAlertException("Invalid id", ENTITY_NAME, "idnull");
+        }
+        if (!Objects.equals(id, financeEntryDTO.getId())) {
+            throw new BadRequestAlertException("Invalid ID", ENTITY_NAME, "idinvalid");
+        }
+
+        if (!financeEntryRepository.existsById(id)) {
+            throw new BadRequestAlertException("Entity not found", ENTITY_NAME, "idnotfound");
+        }
+
+        Optional<FinanceEntryDTO> result = financeEntryService.partialUpdate(financeEntryDTO);
+
+        return ResponseUtil.wrapOrNotFound(
+            result,
+            HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, financeEntryDTO.getId().toString())
+        );
+    }
+
+    @GetMapping("")
+    public List<FinanceEntryDTO> getAllFinanceEntries() {
+        LOG.debug("REST request to get all FinanceEntries");
+        return financeEntryService.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<FinanceEntryDTO> getFinanceEntry(@PathVariable Long id) {
+        LOG.debug("REST request to get FinanceEntry : {}", id);
+        Optional<FinanceEntryDTO> financeEntryDTO = financeEntryService.findOne(id);
+        return ResponseUtil.wrapOrNotFound(financeEntryDTO);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteFinanceEntry(@PathVariable Long id) {
+        LOG.debug("REST request to delete FinanceEntry : {}", id);
+        financeEntryService.delete(id);
+        return ResponseEntity.noContent()
+            .headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, id.toString()))
+            .build();
+    }
+}

--- a/src/main/resources/config/liquibase/changelog/20251110000000_added_entity_FinanceEntry.xml
+++ b/src/main/resources/config/liquibase/changelog/20251110000000_added_entity_FinanceEntry.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
+                        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+  <!--
+      Added the entities FinanceDocument and FinanceEntry.
+  -->
+  <changeSet id="20251110000000-1" author="assistant">
+    <createTable tableName="finance_document">
+      <column name="id" type="bigint">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="file_name" type="varchar(255)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="content_type" type="varchar(255)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="file_size" type="bigint">
+        <constraints nullable="false"/>
+      </column>
+      <column name="data" type="${blobType}">
+        <constraints nullable="false"/>
+      </column>
+      <column name="uploaded_at" type="timestamp">
+        <constraints nullable="true"/>
+      </column>
+      <!-- jhipster-needle-liquibase-add-column - JHipster will add columns here -->
+    </createTable>
+  </changeSet>
+
+  <changeSet id="20251110000000-2" author="assistant">
+    <createTable tableName="finance_entry">
+      <column name="id" type="bigint">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="entry_date" type="date">
+        <constraints nullable="false"/>
+      </column>
+      <column name="entry_type" type="varchar(255)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="amount" type="decimal(21,2)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="description" type="varchar(500)">
+        <constraints nullable="true"/>
+      </column>
+      <column name="document_id" type="bigint">
+        <constraints nullable="true"/>
+      </column>
+      <!-- jhipster-needle-liquibase-add-column - JHipster will add columns here -->
+    </createTable>
+  </changeSet>
+
+  <!-- jhipster-needle-liquibase-add-changeset - JHipster will add changesets here -->
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/changelog/20251110000000_added_entity_constraints_FinanceEntry.xml
+++ b/src/main/resources/config/liquibase/changelog/20251110000000_added_entity_constraints_FinanceEntry.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
+                        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+  <!--
+      Added the constraints for entities FinanceDocument and FinanceEntry.
+  -->
+  <changeSet id="20251110000000-3" author="assistant">
+    <addForeignKeyConstraint
+      baseColumnNames="document_id"
+      baseTableName="finance_entry"
+      constraintName="fk_finance_entry__document_id"
+      referencedColumnNames="id"
+      referencedTableName="finance_document"/>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -20,6 +20,7 @@
   <include file="config/liquibase/changelog/20250927051510_added_entity_Reservation.xml"
            relativeToChangelogFile="false"/>
   <include file="config/liquibase/changelog/20250927051610_added_entity_Payment.xml" relativeToChangelogFile="false"/>
+  <include file="config/liquibase/changelog/20251110000000_added_entity_FinanceEntry.xml" relativeToChangelogFile="false"/>
   <!-- jhipster-needle-liquibase-add-changelog - JHipster will add liquibase changelogs here -->
   <include file="config/liquibase/changelog/20250927051310_added_entity_constraints_OfferedService.xml"
            relativeToChangelogFile="false"/>
@@ -28,6 +29,8 @@
   <include file="config/liquibase/changelog/20250927051510_added_entity_constraints_Reservation.xml"
            relativeToChangelogFile="false"/>
   <include file="config/liquibase/changelog/20250927051610_added_entity_constraints_Payment.xml"
+           relativeToChangelogFile="false"/>
+  <include file="config/liquibase/changelog/20251110000000_added_entity_constraints_FinanceEntry.xml"
            relativeToChangelogFile="false"/>
   <!-- jhipster-needle-liquibase-add-constraints-changelog - JHipster will add liquibase constraints changelogs here -->
   <!-- jhipster-needle-liquibase-add-incremental-changelog - JHipster will add incremental liquibase changelogs here -->


### PR DESCRIPTION
## Summary
- introduce FinanceEntry and FinanceDocument entities with repositories, services, and REST endpoints for managing manual finance data and uploaded invoices
- register Liquibase change logs and caches for the new entities
- extend the Finance page UI with manual entry forms, invoice upload handling, and updated styling alongside new frontend API helpers

## Testing
- npm --prefix frontend run lint *(warning: existing Customers page hook dependency warning)*
- ./mvnw -ntp test *(failed: unable to download Maven binary from repo.maven.apache.org due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68da2e80556083288fbdbcd67bd179ba